### PR TITLE
Switch to global gl functions for Linux/Mac.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@ extern crate libc;
 
 pub mod gl;
 
-// TODO: Switch from static bindings to struct bindings.
-
 mod ffi {
     /// OpenGL 3.0 bindings for Linux/Mac
     #[cfg(not(target_os = "android"))]
@@ -31,7 +29,7 @@ mod ffi {
 		api: "gl",
 		profile: "core",
 		version: "3.0",
-		generator: "static",
+		generator: "global",
 		extensions: [ "GL_ARB_texture_rectangle" ]
 	}
 


### PR DESCRIPTION
This allows us to load the GL function pointers via the platform's GetProcAddress API. This allows us to
switch between headless and windowed rendering at runtime, instead of linking to a different library.
