### PR TITLE
When reading RGBA pixels the size of the array is not properly calculated

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -58,7 +58,7 @@ pub fn delete_frame_buffers(frame_buffers: &[GLuint]) {
 pub fn read_pixels(x: GLint, y: GLint, width: GLsizei, height: GLsizei, format: GLenum, pixel_type: GLenum) -> Vec<u8> {
     let colors = match format {
         ffi::RGB => 3,
-        ffi::RGBA => 3,
+        ffi::RGBA => 4,
         _ => panic!("unsupported format for read_pixels"),
     };
     let depth = match pixel_type {


### PR DESCRIPTION
When reading RGBA each pixel has 4 components and now we consider only 3.