### PR TITLE
Add fallbacks for `clear_depth` and `depth_range` in android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.1.7"
+version = "0.1.8"
 license = "Apache-2.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -483,9 +483,17 @@ pub fn depth_mask(flag: bool) {
 
 #[cfg(not(target_os="android"))]
 #[inline]
-pub fn depth_range(near: GLclampd, far: GLclampd) {
+pub fn depth_range(near: f64, far: f64) {
     unsafe {
-        ffi::DepthRange(near, far);
+        ffi::DepthRange(near as GLclampd, far as GLclampd);
+    }
+}
+
+#[cfg(target_os="android")]
+#[inline]
+pub fn depth_range(near: f64, far: f64) {
+    unsafe {
+        ffi::DepthRangef(near as GLclampf, far as GLclampf);
     }
 }
 
@@ -632,9 +640,17 @@ pub fn clear(buffer_mask: GLbitfield) {
 
 #[cfg(not(target_os="android"))]
 #[inline]
-pub fn clear_depth(depth: GLclampd) {
+pub fn clear_depth(depth: f64) {
     unsafe {
-        ffi::ClearDepth(depth);
+        ffi::ClearDepth(depth as GLclampd);
+    }
+}
+
+#[cfg(target_os="android")]
+#[inline]
+pub fn clear_depth(depth: f64) {
+    unsafe {
+        ffi::ClearDepthf(depth as GLclampf);
     }
 }
 


### PR DESCRIPTION
Also bumps the version no.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/gleam/37)
<!-- Reviewable:end -->
