### PR TITLE
Issue#8462: Add support for bufferSubData, compressedTexImage2D and compressedTexSubImage2D.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.1.17"
+version = "0.1.18"
 license = "Apache-2.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -29,6 +29,16 @@ pub fn buffer_data<T>(target: GLenum, data: &[T], usage: GLenum) {
     }
 }
 
+#[inline]
+pub fn buffer_sub_data<T>(target: GLenum, offset: i64, data: &[T]) {
+    unsafe {
+        ffi::BufferSubData(target,
+                           offset,
+                           (data.len() * size_of::<T>()) as GLsizeiptr,
+                           data.as_ptr() as *const GLvoid);
+    }
+}
+
 pub fn shader_source(shader: GLuint, strings: &[&[u8]]) {
     let pointers: Vec<*const u8> = strings.iter().map(|string| (*string).as_ptr()).collect();
     let lengths: Vec<GLint> = strings.iter().map(|string| string.len() as GLint).collect();
@@ -260,9 +270,8 @@ pub fn tex_image_2d(target: GLenum,
     match opt_data {
         Some(data) => {
             unsafe {
-                let pdata = mem::transmute(data.as_ptr());
                 ffi::TexImage2D(target, level, internal_format, width, height, border, format, ty,
-                               pdata);
+                                data.as_ptr() as *const GLvoid);
             }
         }
         None => {
@@ -271,6 +280,33 @@ pub fn tex_image_2d(target: GLenum,
                                ptr::null());
             }
         }
+    }
+}
+
+pub fn compressed_tex_image_2d(target: GLenum,
+                               level: GLint,
+                               internal_format: GLenum,
+                               width: GLsizei,
+                               height: GLsizei,
+                               border: GLint,
+                               data: &[u8]) {
+    unsafe {
+        ffi::CompressedTexImage2D(target, level, internal_format, width, height, border,
+                                  data.len() as GLsizei, data.as_ptr() as *const GLvoid);
+    }
+}
+
+pub fn compressed_tex_sub_image_2d(target: GLenum,
+                                   level: GLint,
+                                   xoffset: GLint,
+                                   yoffset: GLint,
+                                   width: GLsizei,
+                                   height: GLsizei,
+                                   format: GLenum,
+                                   data: &[u8]) {
+    unsafe {
+        ffi::CompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format,
+                                     data.len() as GLsizei, data.as_ptr() as *const GLvoid);
     }
 }
 


### PR DESCRIPTION
Preparatory work in gleam to fix https://github.com/servo/servo/issues/8462

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/gleam/50)
<!-- Reviewable:end -->
