### PR TITLE
Fix Android compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.2.10"
+version = "0.2.11"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn main() {
             .write_bindings(gl_generator::StaticGenerator, &mut file)
             .unwrap();
 
-        println!("cargo:rustc-link-lib=GLESv2");
+        println!("cargo:rustc-link-lib=GLESv3");
     } else {
         // OpenGL 3.3 bindings for Linux/Mac/Windows
         Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, ["GL_ARB_texture_rectangle"])


### PR DESCRIPTION
We need to link against GLESv3 now, not GLESv2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/72)
<!-- Reviewable:end -->
