### PR TITLE
Fix build on unix-like systems that are not linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ description = "Generated OpenGL bindings and wrapper for Servo."
 
 [build-dependencies]
 gl_generator = "0.5.0"
+pkg-config = "0.3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.2.23"
+version = "0.2.24"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 extern crate gl_generator;
+extern crate pkg_config;
 
 use std::env;
 use std::fs::File;
@@ -29,7 +30,9 @@ fn main() {
         } else if target.contains("windows") {
             println!("cargo:rustc-link-lib=opengl32");
         } else {
-            println!("cargo:rustc-link-lib=GL");
+            if let Err(_) = pkg_config::probe_library("gl") {
+                println!("cargo:rustc-link-lib=GL");
+            }
         }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -24,12 +24,12 @@ fn main() {
             .write_bindings(gl_generator::GlobalGenerator, &mut file)
             .unwrap();
 
-        if target.contains("linux") {
-            println!("cargo:rustc-link-lib=GL");
+        if target.contains("darwin") {
+            println!("cargo:rustc-link-lib=framework=OpenGL");
         } else if target.contains("windows") {
             println!("cargo:rustc-link-lib=opengl32");
         } else {
-            println!("cargo:rustc-link-lib=framework=OpenGL");
+            println!("cargo:rustc-link-lib=GL");
         }
     }
 }


### PR DESCRIPTION
Assuming that everything other than linux or windows uses darwin-style frameworks is... strange ;-)

gleam builds fine on FreeBSD after this change. (update: [got the whole Webrender working](https://unrelenting.technology/notes/2016-10-21-21-16-04)!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/91)
<!-- Reviewable:end -->
