### PR TITLE
Restored ARB_texture_rectangle for non-Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.2.25"
+version = "0.2.26"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@ fn main() {
 
         println!("cargo:rustc-link-lib=GLESv3");
     } else {
-        let extensions = ["GL_EXT_debug_marker"];
+        let extensions = ["GL_ARB_texture_rectangle", "GL_EXT_debug_marker"];
         // OpenGL 3.3 bindings for Linux/Mac/Windows
         Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, extensions)
             .write_bindings(gl_generator::GlobalGenerator, &mut file)


### PR DESCRIPTION
It was removed in #95 but appears to be required by the `IOSurface` for texture sharing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/96)
<!-- Reviewable:end -->
