### PR TITLE
Add api to read pixels into a preallocated buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.2.26"
+version = "0.2.27"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"


### PR DESCRIPTION
Useful for gecko since right now we allocate a copy in gleam, then copy that data out back to gecko across process. Be useful to use shared memory across the pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/97)
<!-- Reviewable:end -->
