### PR TITLE
Add apis for offscreen_gl_context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.2.30"
+version = "0.2.31"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -925,6 +925,27 @@ pub fn is_texture(texture: GLenum) -> GLboolean {
 }
 
 #[inline]
+pub fn is_framebuffer(framebuffer: GLenum) -> GLboolean {
+    unsafe {
+        ffi::IsFramebuffer(framebuffer)
+    }
+}
+
+#[inline]
+pub fn is_renderbuffer(renderbuffer: GLenum) -> GLboolean {
+    unsafe {
+        ffi::IsRenderbuffer(renderbuffer)
+    }
+}
+
+#[inline]
+pub fn check_frame_buffer_status(target: GLenum) -> GLenum {
+    unsafe {
+        ffi::CheckFramebufferStatus(target)
+    }
+}
+
+#[inline]
 pub fn enable_vertex_attrib_array(index: GLuint) {
     unsafe {
         ffi::EnableVertexAttribArray(index);


### PR DESCRIPTION
offscreen_gl_context uses some ffi functions of gleam. To replace the functions with public functions, the following 3 functions are necessary. See also [1]
 - gl::is_framebuffer()
 - gl::is_renderbuffer()
 - gl::check_frame_buffer_status()

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1331546

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/102)
<!-- Reviewable:end -->
