### PR TITLE
Make load_with be unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.3.0"
+version = "0.4.0"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -13,7 +13,7 @@ pub struct GlFns {
 
 impl GlFns
 {
-    pub fn load_with<'a, F>(loadfn: F) -> Rc<Gl> where F: FnMut(&str) -> *const c_void {
+    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<Gl> where F: FnMut(&str) -> *const c_void {
         let ffi_gl_ = GlFfi::load_with(loadfn);
         Rc::new(GlFns {
             ffi_gl_: ffi_gl_,

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -13,7 +13,7 @@ pub struct GlesFns {
 
 impl GlesFns
 {
-    pub fn load_with<'a, F>(loadfn: F) -> Rc<Gl> where F: FnMut(&str) -> *const c_void {
+    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<Gl> where F: FnMut(&str) -> *const c_void {
         let ffi_gl_ = GlesFfi::load_with(loadfn);
         Rc::new(GlesFns {
             ffi_gl_: ffi_gl_,


### PR DESCRIPTION
Fixed servo/gleam#112
version is updated to 0.4.0, since it causes build break.

cc @kvark , @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/113)
<!-- Reviewable:end -->
