### PR TITLE
Fix GlesFns::get_type()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.0"
+version = "0.4.1"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -28,7 +28,7 @@ extern {
 
 impl Gl for GlesFns {
     fn get_type(&self) -> GlType {
-        GlType::Gl
+        GlType::Gles
     }
 
     fn buffer_data_untyped(&self, target: GLenum, size: GLsizeiptr, data: *const GLvoid, usage: GLenum) {


### PR DESCRIPTION
GlesFns::get_type() returns GlType::Gl now. It should be GlType::Gles.

The fix is related to servo/webrender#771.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/114)
<!-- Reviewable:end -->
