### PR TITLE
Remove link to glEGLImageTargetTexture2DOES() in gleam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
           .unwrap();
 
     // GLES 2.0 bindings
-    let gles_extensions = ["GL_EXT_texture_format_BGRA8888"];
+    let gles_extensions = ["GL_EXT_texture_format_BGRA8888", "GL_OES_EGL_image"];
     let gles_reg = Registry::new(Api::Gles2, (3, 0), Profile::Core, Fallbacks::All, gles_extensions);
     gles_reg.write_bindings(gl_generator::StructGenerator, &mut file_gles)
             .unwrap();

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -21,11 +21,6 @@ impl GlesFns
     }
 }
 
-#[cfg(target_os="android")]
-extern {
-    fn glEGLImageTargetTexture2DOES(target: GLenum, image: GLeglImageOES);
-}
-
 impl Gl for GlesFns {
     fn get_type(&self) -> GlType {
         GlType::Gles
@@ -1279,7 +1274,7 @@ impl Gl for GlesFns {
     #[cfg(target_os="android")]
     fn egl_image_target_texture2d_oes(&self, target: GLenum, image: GLeglImageOES) {
         unsafe {
-            glEGLImageTargetTexture2DOES(target, image);
+            self.ffi_gl_.EGLImageTargetTexture2DOES(target, image);
         }
     }
 


### PR DESCRIPTION
Current gleam removes almost all link to gl functions. But a link to glEGLImageTargetTexture2DOES() stills exists.

cc @emilio, @kvark.

https://bugzilla.mozilla.org/show_bug.cgi?id=1351643

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/116)
<!-- Reviewable:end -->
