### PR TITLE
Implement getShaderPrecisionFormat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.2"
+version = "0.4.3"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -357,6 +357,10 @@ pub trait Gl {
     fn get_shader_info_log(&self, shader: GLuint) -> String;
     fn get_string(&self, which: GLenum) -> String;
     fn get_shader_iv(&self, shader: GLuint, pname: GLenum) -> GLint;
+    fn get_shader_precision_format(&self,
+                                   shader_type: GLuint,
+                                   precision_type: GLuint)
+                                   -> (GLint, GLint, GLint);
     fn compile_shader(&self, shader: GLuint);
     fn create_program(&self) -> GLuint;
     fn delete_program(&self, program: GLuint);

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -1157,6 +1157,28 @@ impl Gl for GlFns {
         }
     }
 
+    fn get_shader_precision_format(&self, _shader_type: GLuint, precision_type: GLuint) -> (GLint, GLint, GLint) {
+        // gl.GetShaderPrecisionFormat is not available until OpenGL 4.1.
+        // Fallback to OpenGL standard precissions that most desktop hardware support.
+        match precision_type {
+            ffi::LOW_FLOAT | ffi::MEDIUM_FLOAT | ffi::HIGH_FLOAT => {
+                // Fallback to IEEE 754 single precision
+                // Range: from -2^127 to 2^127
+                // Significand precision: 23 bits
+                (127, 127, 23)
+            },
+            ffi::LOW_INT | ffi::MEDIUM_INT | ffi::HIGH_INT => {
+                // Fallback to single precision integer
+                // Range: from -2^24 to 2^24
+                // Precision: For integer formats this value is always 0
+                (24, 24, 0)
+            },
+            _ => {
+                (0, 0, 0)
+            }
+        }
+    }
+
     fn compile_shader(&self, shader: GLuint) {
         unsafe {
             self.ffi_gl_.CompileShader(shader);

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -1131,6 +1131,21 @@ impl Gl for GlesFns {
         }
     }
 
+    fn get_shader_precision_format(&self,
+                                   shader_type: GLuint,
+                                   precision_type: GLuint)
+                                   -> (GLint, GLint, GLint) {
+        let mut range = [0 as GLint, 0];
+        let mut precision = 0 as GLint;
+        unsafe {
+            self.ffi_gl_.GetShaderPrecisionFormat(shader_type,
+                                                  precision_type,
+                                                  range.as_mut_ptr(),
+                                                  &mut precision);
+        }
+        (range[0], range[1], precision)
+    }
+
     fn compile_shader(&self, shader: GLuint) {
         unsafe {
             self.ffi_gl_.CompileShader(shader);


### PR DESCRIPTION
Required for WebGL implementation. Some game engines like Three.js use this function to set precision in the shaders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/119)
<!-- Reviewable:end -->
