### PR TITLE
Change TexSubImage2D and TexSubImage3D to use pointers instead of slices.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.5"
+version = "0.4.6"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -214,6 +214,16 @@ pub trait Gl {
                         format: GLenum,
                         ty: GLenum,
                         data: &[u8]);
+    fn tex_sub_image_2d_pbo(&self,
+                            target: GLenum,
+                            level: GLint,
+                            xoffset: GLint,
+                            yoffset: GLint,
+                            width: GLsizei,
+                            height: GLsizei,
+                            format: GLenum,
+                            ty: GLenum,
+                            offset: usize);
     fn tex_sub_image_3d(&self,
                         target: GLenum,
                         level: GLint,

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -508,6 +508,21 @@ impl Gl for GlFns {
         }
     }
 
+    fn tex_sub_image_2d_pbo(&self,
+                            target: GLenum,
+                            level: GLint,
+                            xoffset: GLint,
+                            yoffset: GLint,
+                            width: GLsizei,
+                            height: GLsizei,
+                            format: GLenum,
+                            ty: GLenum,
+                            offset: usize) {
+        unsafe {
+            self.ffi_gl_.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, ty, offset as *const c_void);
+        }
+    }
+
     fn tex_sub_image_3d(&self,
                         target: GLenum,
                         level: GLint,

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -486,6 +486,21 @@ impl Gl for GlesFns {
         }
     }
 
+    fn tex_sub_image_2d_pbo(&self,
+                            target: GLenum,
+                            level: GLint,
+                            xoffset: GLint,
+                            yoffset: GLint,
+                            width: GLsizei,
+                            height: GLsizei,
+                            format: GLenum,
+                            ty: GLenum,
+                            offset: usize) {
+        unsafe {
+            self.ffi_gl_.TexSubImage2D(target, level, xoffset, yoffset, width, height, format, ty, offset as *const c_void);
+        }
+    }
+
     fn tex_sub_image_3d(&self,
                         target: GLenum,
                         level: GLint,


### PR DESCRIPTION
This allows using these functions when using PBOs, where the parameter
is actually a byte offset into a pixel buffer object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/123)
<!-- Reviewable:end -->
