### PR TITLE
Update gl_generator (fixes broken build)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/servo/gleam"
 description = "Generated OpenGL bindings and wrapper for Servo."
 
 [build-dependencies]
-gl_generator = "0.5.0"
+gl_generator = "0.6.0"
 pkg-config = "0.3.8"


### PR DESCRIPTION
gl_generator 0.5.5 currently fails to build on Mac OS X as can be seen [here](https://travis-ci.org/tomaka/glutin/jobs/297511842) probably due some breaking changes which [were released some hours ago](https://github.com/brendanzab/gl-rs/pull/432).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/130)
<!-- Reviewable:end -->
