### PR TITLE
Add methods required for Uniform Buffer Objects in WebGL 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.13"
+version = "0.4.14"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -130,6 +130,7 @@ pub trait Gl {
     fn attach_shader(&self, program: GLuint, shader: GLuint);
     fn bind_attrib_location(&self, program: GLuint, index: GLuint, name: &str);
     fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint;
+    fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint>;
     fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint);
     fn uniform_block_binding(&self,
                              program: GLuint,

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -132,6 +132,7 @@ pub trait Gl {
     fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint;
     fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint>;
     fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint);
+    fn bind_buffer_range(&self, target: GLenum, index: GLuint, buffer: GLuint, offset: GLintptr, size: GLsizeiptr);
     fn uniform_block_binding(&self,
                              program: GLuint,
                              uniform_block_index: GLuint,

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -374,6 +374,10 @@ pub trait Gl {
     fn depth_range(&self, near: f64, far: f64);
     fn get_active_attrib(&self, program: GLuint, index: GLuint) -> (i32, u32, String);
     fn get_active_uniform(&self, program: GLuint, index: GLuint) -> (i32, u32, String);
+    fn get_active_uniforms_iv(&self, program: GLuint, indices: Vec<GLuint>, pname: GLenum) -> Vec<GLint>;
+    fn get_active_uniform_block_i(&self, program: GLuint, index: GLuint, pname: GLenum) -> GLint;
+    fn get_active_uniform_block_iv(&self, program: GLuint, index: GLuint, pname: GLenum) -> Vec<GLint>;
+    fn get_active_uniform_block_name(&self, program: GLuint, index: GLuint) -> String;
     fn get_attrib_location(&self, program: GLuint, name: &str) -> c_int;
     fn get_frag_data_location(&self, program: GLuint, name: &str) -> c_int;
     fn get_uniform_location(&self, program: GLuint, name: &str) -> c_int;

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -251,6 +251,9 @@ pub trait Gl {
                             ty: GLenum,
                             offset: usize);
     fn get_integer_v(&self, name: GLenum) -> GLint;
+    fn get_integer_64v(&self, name: GLenum) -> GLint64;
+    fn get_integer_iv(&self, name: GLenum, index: GLuint) -> GLint;
+    fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64;
     fn get_boolean_v(&self, name: GLenum) -> GLboolean;
     fn get_float_v(&self, name: GLenum) -> GLfloat;
     fn tex_parameter_i(&self, target: GLenum, pname: GLenum, param: GLint);

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -320,6 +320,12 @@ impl Gl for GlFns {
         }
     }
 
+    fn bind_buffer_range(&self, target: GLenum, index: GLuint, buffer: GLuint, offset: GLintptr, size: GLsizeiptr) {
+        unsafe {
+            self.ffi_gl_.BindBufferRange(target, index, buffer, offset, size);
+        }
+    }
+
     fn uniform_block_binding(&self, program: GLuint, uniform_block_index: GLuint, uniform_block_binding: GLuint) {
         unsafe {
             self.ffi_gl_.UniformBlockBinding(program, uniform_block_index, uniform_block_binding);

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -300,6 +300,20 @@ impl Gl for GlFns {
         }
     }
 
+    fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint> {
+        let c_strings: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
+        let pointers: Vec<*const GLchar> = c_strings.iter().map(|string| string.as_ptr()).collect();
+        let mut result = Vec::with_capacity(c_strings.len());
+        unsafe {
+            result.set_len(c_strings.len());
+            self.ffi_gl_.GetUniformIndices(program,
+                                           pointers.len() as GLsizei,
+                                           pointers.as_ptr(),
+                                           result.as_mut_ptr());
+        }
+        result
+    }
+
     fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint) {
         unsafe {
             self.ffi_gl_.BindBufferBase(target, index, buffer);

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -578,9 +578,33 @@ impl Gl for GlFns {
     }
 
     fn get_integer_v(&self, name: GLenum) -> GLint {
-        let mut result: GLint = 0 as GLint;
+        let mut result = 0;
         unsafe {
             self.ffi_gl_.GetIntegerv(name, &mut result);
+        }
+        result
+    }
+
+    fn get_integer_64v(&self, name: GLenum) -> GLint64 {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetInteger64v(name, &mut result);
+        }
+        result
+    }
+
+    fn get_integer_iv(&self, name: GLenum, index: GLuint) -> GLint {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetIntegeri_v(name, index, &mut result);
+        }
+        result
+    }
+
+    fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64 {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetInteger64i_v(name, index, &mut result);
         }
         result
     }

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -1131,6 +1131,53 @@ impl Gl for GlFns {
         (size, type_, String::from_utf8(name).unwrap())
     }
 
+    fn get_active_uniforms_iv(&self, program: GLuint, indices: Vec<GLuint>, pname: GLenum) -> Vec<GLint> {
+        let mut result = Vec::with_capacity(indices.len());
+        unsafe {
+            result.set_len(indices.len());
+            self.ffi_gl_.GetActiveUniformsiv(program,
+                                             indices.len() as GLsizei,
+                                             indices.as_ptr(),
+                                             pname,
+                                             result.as_mut_ptr());
+        }
+        result
+    }
+
+    fn get_active_uniform_block_i(&self, program: GLuint, index: GLuint, pname: GLenum) -> GLint {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetActiveUniformBlockiv(program, index, pname, &mut result);
+        }
+        result
+    }
+
+    fn get_active_uniform_block_iv(&self, program: GLuint, index: GLuint, pname: GLenum) -> Vec<GLint> {
+        let count = self.get_active_uniform_block_i(program, index, ffi::UNIFORM_BLOCK_ACTIVE_UNIFORMS);
+        let mut result = Vec::with_capacity(count as usize);
+        unsafe {
+            result.set_len(count as usize);
+            self.ffi_gl_.GetActiveUniformBlockiv(program, index, pname, result.as_mut_ptr());
+        }
+        result
+    }
+
+    fn get_active_uniform_block_name(&self, program: GLuint, index: GLuint) -> String {
+        let buf_size = self.get_active_uniform_block_i(program, index, ffi::UNIFORM_BLOCK_NAME_LENGTH);
+        let mut name = vec![0 as u8; buf_size as usize];
+        let mut length: GLsizei = 0;
+        unsafe {
+            self.ffi_gl_.GetActiveUniformBlockName(program,
+                                                   index,
+                                                   buf_size,
+                                                   &mut length,
+                                                   name.as_mut_ptr() as *mut GLchar);
+        }
+        name.truncate(if length > 0 { length as usize } else { 0 });
+
+        String::from_utf8(name).unwrap()
+    }
+
     fn get_attrib_location(&self, program: GLuint, name: &str) -> c_int {
         let name = CString::new(name).unwrap();
         unsafe {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -278,6 +278,20 @@ impl Gl for GlesFns {
         }
     }
 
+    fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint> {
+        let c_strings: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
+        let pointers: Vec<*const GLchar> = c_strings.iter().map(|string| string.as_ptr()).collect();
+        let mut result = Vec::with_capacity(c_strings.len());
+        unsafe {
+            result.set_len(c_strings.len());
+            self.ffi_gl_.GetUniformIndices(program,
+                                           pointers.len() as GLsizei,
+                                           pointers.as_ptr(),
+                                           result.as_mut_ptr());
+        }
+        result
+    }
+
     fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint) {
         unsafe {
             self.ffi_gl_.BindBufferBase(target, index, buffer);

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -556,9 +556,33 @@ impl Gl for GlesFns {
     }
 
     fn get_integer_v(&self, name: GLenum) -> GLint {
-        let mut result: GLint = 0 as GLint;
+        let mut result = 0;
         unsafe {
             self.ffi_gl_.GetIntegerv(name, &mut result);
+        }
+        result
+    }
+
+    fn get_integer_64v(&self, name: GLenum) -> GLint64 {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetInteger64v(name, &mut result);
+        }
+        result
+    }
+
+    fn get_integer_iv(&self, name: GLenum, index: GLuint) -> GLint {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetIntegeri_v(name, index, &mut result);
+        }
+        result
+    }
+
+    fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64 {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetInteger64i_v(name, index, &mut result);
         }
         result
     }

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -298,6 +298,12 @@ impl Gl for GlesFns {
         }
     }
 
+    fn bind_buffer_range(&self, target: GLenum, index: GLuint, buffer: GLuint, offset: GLintptr, size: GLsizeiptr) {
+        unsafe {
+            self.ffi_gl_.BindBufferRange(target, index, buffer, offset, size);
+        }
+    }
+
     fn uniform_block_binding(&self, program: GLuint, uniform_block_index: GLuint, uniform_block_binding: GLuint) {
         unsafe {
             self.ffi_gl_.UniformBlockBinding(program, uniform_block_index, uniform_block_binding);

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -1105,6 +1105,53 @@ impl Gl for GlesFns {
         (size, type_, String::from_utf8(name).unwrap())
     }
 
+    fn get_active_uniforms_iv(&self, program: GLuint, indices: Vec<GLuint>, pname: GLenum) -> Vec<GLint> {
+        let mut result = Vec::with_capacity(indices.len());
+        unsafe {
+            result.set_len(indices.len());
+            self.ffi_gl_.GetActiveUniformsiv(program,
+                                             indices.len() as GLsizei,
+                                             indices.as_ptr(),
+                                             pname,
+                                             result.as_mut_ptr());
+        }
+        result
+    }
+
+    fn get_active_uniform_block_i(&self, program: GLuint, index: GLuint, pname: GLenum) -> GLint {
+        let mut result = 0;
+        unsafe {
+            self.ffi_gl_.GetActiveUniformBlockiv(program, index, pname, &mut result);
+        }
+        result
+    }
+
+    fn get_active_uniform_block_iv(&self, program: GLuint, index: GLuint, pname: GLenum) -> Vec<GLint> {
+        let count = self.get_active_uniform_block_i(program, index, ffi::UNIFORM_BLOCK_ACTIVE_UNIFORMS);
+        let mut result = Vec::with_capacity(count as usize);
+        unsafe {
+            result.set_len(count as usize);
+            self.ffi_gl_.GetActiveUniformBlockiv(program, index, pname, result.as_mut_ptr());
+        }
+        result
+    }
+
+    fn get_active_uniform_block_name(&self, program: GLuint, index: GLuint) -> String {
+        let buf_size = self.get_active_uniform_block_i(program, index, ffi::UNIFORM_BLOCK_NAME_LENGTH);
+        let mut name = vec![0 as u8; buf_size as usize];
+        let mut length: GLsizei = 0;
+        unsafe {
+            self.ffi_gl_.GetActiveUniformBlockName(program,
+                                                   index,
+                                                   buf_size,
+                                                   &mut length,
+                                                   name.as_mut_ptr() as *mut GLchar);
+        }
+        name.truncate(if length > 0 { length as usize } else { 0 });
+
+        String::from_utf8(name).unwrap()
+    }
+
     fn get_attrib_location(&self, program: GLuint, name: &str) -> c_int {
         let name = CString::new(name).unwrap();
         unsafe {


### PR DESCRIPTION
Add methods required for Uniform Buffer Objects spec in WebGL 2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/133)
<!-- Reviewable:end -->
