### PR TITLE
Expose glGetFramebufferParameterIv.

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -265,6 +265,10 @@ pub trait Gl {
     fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64;
     fn get_boolean_v(&self, name: GLenum) -> GLboolean;
     fn get_float_v(&self, name: GLenum) -> GLfloat;
+    fn get_framebuffer_attachment_parameter_iv(&self,
+                                               target: GLenum,
+                                               attachment: GLenum,
+                                               pname: GLenum) -> GLint;
     fn get_tex_parameter_iv(&self, target: GLenum, name: GLenum) -> GLint;
     fn get_tex_parameter_fv(&self, target: GLenum, name: GLenum) -> GLfloat;
     fn tex_parameter_i(&self, target: GLenum, pname: GLenum, param: GLint);

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -660,6 +660,14 @@ impl Gl for GlFns {
         result
     }
 
+    fn get_framebuffer_attachment_parameter_iv(&self, target: GLenum, attachment: GLenum, pname: GLenum) -> GLint {
+        let mut result: GLint = 0;
+        unsafe {
+            self.ffi_gl_.GetFramebufferAttachmentParameteriv(target, attachment, pname, &mut result);
+        }
+        result
+    }
+
     fn get_tex_parameter_iv(&self, target: GLenum, pname: GLenum) -> GLint {
         let mut result: GLint = 0;
         unsafe {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -680,6 +680,14 @@ impl Gl for GlesFns {
         result
     }
 
+    fn get_framebuffer_attachment_parameter_iv(&self, target: GLenum, attachment: GLenum, pname: GLenum) -> GLint {
+        let mut result: GLint = 0;
+        unsafe {
+            self.ffi_gl_.GetFramebufferAttachmentParameteriv(target, attachment, pname, &mut result);
+        }
+        result
+    }
+
     fn get_tex_parameter_iv(&self, target: GLenum, pname: GLenum) -> GLint {
         let mut result: GLint = 0;
         unsafe {


### PR DESCRIPTION
I'd like to use it to check whether we have a depth buffer available when initializing WebRender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/144)
<!-- Reviewable:end -->
