### PR TITLE
Implement direct exposure of glDrawBuffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.24"
+version = "0.4.25"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -143,6 +143,7 @@ pub trait Gl {
     fn bind_renderbuffer(&self, target: GLenum, renderbuffer: GLuint);
     fn bind_framebuffer(&self, target: GLenum, framebuffer: GLuint);
     fn bind_texture(&self, target: GLenum, texture: GLuint);
+    fn draw_buffers(&self, bufs: &[GLenum]);
     fn tex_image_2d(&self,
                     target: GLenum,
                     level: GLint,

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -362,6 +362,12 @@ impl Gl for GlFns {
         }
     }
 
+    fn draw_buffers(&self, bufs: &[GLenum]) {
+        unsafe {
+            self.ffi_gl_.DrawBuffers(bufs.len() as GLsizei, bufs.as_ptr());
+        }
+    }
+
     // FIXME: Does not verify buffer size -- unsafe!
     fn tex_image_2d(&self,
                     target: GLenum,

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -386,6 +386,12 @@ impl Gl for GlesFns {
         }
     }
 
+    fn draw_buffers(&self, bufs: &[GLenum]) {
+        unsafe {
+            self.ffi_gl_.DrawBuffers(bufs.len() as GLsizei, bufs.as_ptr());
+        }
+    }
+
     // FIXME: Does not verify buffer size -- unsafe!
     fn tex_image_2d(&self,
                     target: GLenum,


### PR DESCRIPTION
This is unsafe since it doesn't check the bounds of the buffer of enums. I'm not sure if it's the responsibility of the API to guarantee that the length of the slice is greater or equal to the length parameter specified, and how best to notify the user.
Or even if it would be better off not mirroring the GL API directly in the interface, and retrieving the length from the slice instead.

Fixes #148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/149)
<!-- Reviewable:end -->
