### PR TITLE
Fix: determine the length of the vector with uniform values by the type of uniform variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.30"
+version = "0.4.31"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -63,8 +63,8 @@ fn calculate_length(width: GLsizei, height: GLsizei, format: GLenum, pixel_type:
 }
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-fn get_uniform_iv_vector_length(location: &GLint) -> usize {
-    match *location as u32 {
+fn get_uniform_iv_vector_length(uniform_type: &GLuint) -> usize {
+    match *uniform_type {
         ffi::BOOL |
         ffi::INT |
         ffi::SAMPLER_2D |
@@ -80,8 +80,8 @@ fn get_uniform_iv_vector_length(location: &GLint) -> usize {
 }
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-fn get_uniform_fv_vector_length(location: &GLint) -> usize {
-    match *location as u32 {
+fn get_uniform_fv_vector_length(uniform_type: &GLuint) -> usize {
+    match *uniform_type {
         ffi::FLOAT => 1,
         ffi::FLOAT_VEC2 => 2,
         ffi::FLOAT_VEC3 => 3,

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -19,6 +19,21 @@ impl GlFns
             ffi_gl_: ffi_gl_,
         }) as Rc<Gl>
     }
+
+    fn get_active_uniform_type(&self, program: GLuint) -> GLuint {
+        let mut size: GLint = 0;
+        let mut uniform_type: GLuint = 0;
+        unsafe {
+            self.ffi_gl_.GetActiveUniform(program,
+                                          0 as GLuint,
+                                          0 as GLsizei,
+                                          ptr::null_mut(),
+                                          &mut size,
+                                          &mut uniform_type,
+                                          ptr::null_mut());
+        }
+        uniform_type
+    }
 }
 
 impl Gl for GlFns {
@@ -295,7 +310,8 @@ impl Gl for GlFns {
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
     fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint> {
-        let len = get_uniform_iv_vector_length(&location);
+        let uniform_type = self.get_active_uniform_type(program);
+        let len = get_uniform_iv_vector_length(&uniform_type);
         let mut result: [GLint; 4] = [0; 4];
         unsafe {
             self.ffi_gl_.GetUniformiv(program, location, result.as_mut_ptr());
@@ -305,7 +321,8 @@ impl Gl for GlFns {
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
     fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat> {
-        let len = get_uniform_fv_vector_length(&location);
+        let uniform_type = self.get_active_uniform_type(program);
+        let len = get_uniform_fv_vector_length(&uniform_type);
         let mut result: [GLfloat; 16] = [0.0; 16];
         unsafe {
             self.ffi_gl_.GetUniformfv(program, location, result.as_mut_ptr());

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -19,6 +19,21 @@ impl GlesFns
             ffi_gl_: ffi_gl_,
         }) as Rc<Gl>
     }
+
+    fn get_active_uniform_type(&self, program: GLuint) -> GLuint {
+        let mut size: GLint = 0;
+        let mut uniform_type: GLuint = 0;
+        unsafe {
+            self.ffi_gl_.GetActiveUniform(program,
+                                          0 as GLuint,
+                                          0 as GLsizei,
+                                          ptr::null_mut(),
+                                          &mut size,
+                                          &mut uniform_type,
+                                          ptr::null_mut());
+        }
+        uniform_type
+    }
 }
 
 impl Gl for GlesFns {
@@ -319,7 +334,8 @@ impl Gl for GlesFns {
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
     fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint> {
-        let len = get_uniform_iv_vector_length(&location);
+        let uniform_type = self.get_active_uniform_type(program);
+        let len = get_uniform_iv_vector_length(&uniform_type);
         let mut result: [GLint; 4] = [0; 4];
         unsafe {
             self.ffi_gl_.GetUniformiv(program, location, result.as_mut_ptr());
@@ -329,7 +345,8 @@ impl Gl for GlesFns {
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
     fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat> {
-        let len = get_uniform_fv_vector_length(&location);
+        let uniform_type = self.get_active_uniform_type(program);
+        let len = get_uniform_fv_vector_length(&uniform_type);
         let mut result: [GLfloat; 16] = [0.0; 16];
         unsafe {
             self.ffi_gl_.GetUniformfv(program, location, result.as_mut_ptr());


### PR DESCRIPTION
Currently we match on location to determine the number of uniform values to return, while we should do so by matching on the type.

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/159)
<!-- Reviewable:end -->
