### PR TITLE
Dumb down some methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.4.35"
+version = "0.5.0"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -102,13 +102,14 @@ pub struct DebugMessage {
 }
 
 macro_rules! declare_gl_apis {
-    (pub trait Gl { $(fn $name:ident(&self$(, $arg:ident: $t:ty)*$(,)*)$( -> $retty:ty)*;)+ }) => {
+    // garbo is a hack to handle unsafe methods.
+    ($($(unsafe $([$garbo:expr])*)* fn $name:ident(&self $(, $arg:ident: $t:ty)* $(,)*) $(-> $retty:ty)* ;)+) => {
         pub trait Gl {
-            $(fn $name(&self$(, $arg:$t)*)$( -> $retty)*;)+
+            $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* ;)+
         }
 
         impl Gl for ErrorCheckingGl {
-            $(fn $name(&self$(, $arg:$t)*)$( -> $retty)* {
+            $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* {
                 let rv = self.gl.$name($($arg,)*);
                 assert_eq!(self.gl.get_error(), 0);
                 rv
@@ -118,156 +119,165 @@ macro_rules! declare_gl_apis {
 }
 
 declare_gl_apis! {
-    pub trait Gl {
-        fn get_type(&self) -> GlType;
-        fn buffer_data_untyped(&self,
-                               target: GLenum,
-                               size: GLsizeiptr,
-                               data: *const GLvoid,
-                               usage: GLenum);
-        fn buffer_sub_data_untyped(&self,
-                                   target: GLenum,
-                                   offset: isize,
-                                   size: GLsizeiptr,
-                                   data: *const GLvoid);
-        fn tex_buffer(&self, target: GLenum, internal_format: GLenum, buffer: GLuint);
-        fn shader_source(&self, shader: GLuint, strings: &[&[u8]]);
-        fn read_buffer(&self, mode: GLenum);
-        fn read_pixels_into_buffer(&self,
-                                   x: GLint,
-                                   y: GLint,
-                                   width: GLsizei,
-                                   height: GLsizei,
-                                   format: GLenum,
-                                   pixel_type: GLenum,
-                                   dst_buffer: &mut [u8]);
-        fn read_pixels(&self,
-                       x: GLint,
-                       y: GLint,
-                       width: GLsizei,
-                       height: GLsizei,
-                       format: GLenum,
-                       pixel_type: GLenum)
-                       -> Vec<u8>;
-        fn sample_coverage(&self, value: GLclampf, invert: bool);
-        fn polygon_offset(&self, factor: GLfloat, units: GLfloat);
-        fn pixel_store_i(&self, name: GLenum, param: GLint);
-        fn gen_buffers(&self, n: GLsizei) -> Vec<GLuint>;
-        fn gen_renderbuffers(&self, n: GLsizei) -> Vec<GLuint>;
-        fn gen_framebuffers(&self, n: GLsizei) -> Vec<GLuint>;
-        fn gen_textures(&self, n: GLsizei) -> Vec<GLuint>;
-        fn gen_vertex_arrays(&self, n: GLsizei) -> Vec<GLuint>;
-        fn gen_queries(&self, n: GLsizei) -> Vec<GLuint>;
-        fn begin_query(&self, target: GLenum, id: GLuint);
-        fn end_query(&self, target: GLenum);
-        fn query_counter(&self, id: GLuint, target: GLenum);
-        fn get_query_object_iv(&self, id: GLuint, pname: GLenum) -> i32;
-        fn get_query_object_uiv(&self, id: GLuint, pname: GLenum) -> u32;
-        fn get_query_object_i64v(&self, id: GLuint, pname: GLenum) -> i64;
-        fn get_query_object_ui64v(&self, id: GLuint, pname: GLenum) -> u64;
-        fn delete_queries(&self, queries: &[GLuint]);
-        fn delete_vertex_arrays(&self, vertex_arrays: &[GLuint]);
-        fn delete_buffers(&self, buffers: &[GLuint]);
-        fn delete_renderbuffers(&self, renderbuffers: &[GLuint]);
-        fn delete_framebuffers(&self, framebuffers: &[GLuint]);
-        fn delete_textures(&self, textures: &[GLuint]);
-        fn framebuffer_renderbuffer(&self,
-                                    target: GLenum,
-                                    attachment: GLenum,
-                                    renderbuffertarget: GLenum,
-                                    renderbuffer: GLuint);
-        fn renderbuffer_storage(&self,
+    fn get_type(&self) -> GlType;
+    fn buffer_data_untyped(&self,
+                            target: GLenum,
+                            size: GLsizeiptr,
+                            data: *const GLvoid,
+                            usage: GLenum);
+    fn buffer_sub_data_untyped(&self,
                                 target: GLenum,
-                                internalformat: GLenum,
+                                offset: isize,
+                                size: GLsizeiptr,
+                                data: *const GLvoid);
+    fn tex_buffer(&self, target: GLenum, internal_format: GLenum, buffer: GLuint);
+    fn shader_source(&self, shader: GLuint, strings: &[&[u8]]);
+    fn read_buffer(&self, mode: GLenum);
+    fn read_pixels_into_buffer(&self,
+                                x: GLint,
+                                y: GLint,
+                                width: GLsizei,
+                                height: GLsizei,
+                                format: GLenum,
+                                pixel_type: GLenum,
+                                dst_buffer: &mut [u8]);
+    fn read_pixels(&self,
+                    x: GLint,
+                    y: GLint,
+                    width: GLsizei,
+                    height: GLsizei,
+                    format: GLenum,
+                    pixel_type: GLenum)
+                    -> Vec<u8>;
+    fn sample_coverage(&self, value: GLclampf, invert: bool);
+    fn polygon_offset(&self, factor: GLfloat, units: GLfloat);
+    fn pixel_store_i(&self, name: GLenum, param: GLint);
+    fn gen_buffers(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_renderbuffers(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_framebuffers(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_textures(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_vertex_arrays(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_queries(&self, n: GLsizei) -> Vec<GLuint>;
+    fn begin_query(&self, target: GLenum, id: GLuint);
+    fn end_query(&self, target: GLenum);
+    fn query_counter(&self, id: GLuint, target: GLenum);
+    fn get_query_object_iv(&self, id: GLuint, pname: GLenum) -> i32;
+    fn get_query_object_uiv(&self, id: GLuint, pname: GLenum) -> u32;
+    fn get_query_object_i64v(&self, id: GLuint, pname: GLenum) -> i64;
+    fn get_query_object_ui64v(&self, id: GLuint, pname: GLenum) -> u64;
+    fn delete_queries(&self, queries: &[GLuint]);
+    fn delete_vertex_arrays(&self, vertex_arrays: &[GLuint]);
+    fn delete_buffers(&self, buffers: &[GLuint]);
+    fn delete_renderbuffers(&self, renderbuffers: &[GLuint]);
+    fn delete_framebuffers(&self, framebuffers: &[GLuint]);
+    fn delete_textures(&self, textures: &[GLuint]);
+    fn framebuffer_renderbuffer(&self,
+                                target: GLenum,
+                                attachment: GLenum,
+                                renderbuffertarget: GLenum,
+                                renderbuffer: GLuint);
+    fn renderbuffer_storage(&self,
+                            target: GLenum,
+                            internalformat: GLenum,
+                            width: GLsizei,
+                            height: GLsizei);
+    fn depth_func(&self, func: GLenum);
+    fn active_texture(&self, texture: GLenum);
+    fn attach_shader(&self, program: GLuint, shader: GLuint);
+    fn bind_attrib_location(&self, program: GLuint, index: GLuint, name: &str);
+    fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint>;
+    fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat>;
+    fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint;
+    fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint>;
+    fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint);
+    fn bind_buffer_range(&self, target: GLenum, index: GLuint, buffer: GLuint, offset: GLintptr, size: GLsizeiptr);
+    fn uniform_block_binding(&self,
+                                program: GLuint,
+                                uniform_block_index: GLuint,
+                                uniform_block_binding: GLuint);
+    fn bind_buffer(&self, target: GLenum, buffer: GLuint);
+    fn bind_vertex_array(&self, vao: GLuint);
+    fn bind_renderbuffer(&self, target: GLenum, renderbuffer: GLuint);
+    fn bind_framebuffer(&self, target: GLenum, framebuffer: GLuint);
+    fn bind_texture(&self, target: GLenum, texture: GLuint);
+    fn draw_buffers(&self, bufs: &[GLenum]);
+    fn tex_image_2d(&self,
+                    target: GLenum,
+                    level: GLint,
+                    internal_format: GLint,
+                    width: GLsizei,
+                    height: GLsizei,
+                    border: GLint,
+                    format: GLenum,
+                    ty: GLenum,
+                    opt_data: Option<&[u8]>);
+    fn compressed_tex_image_2d(&self,
+                                target: GLenum,
+                                level: GLint,
+                                internal_format: GLenum,
+                                width: GLsizei,
+                                height: GLsizei,
+                                border: GLint,
+                                data: &[u8]);
+    fn compressed_tex_sub_image_2d(&self,
+                                    target: GLenum,
+                                    level: GLint,
+                                    xoffset: GLint,
+                                    yoffset: GLint,
+                                    width: GLsizei,
+                                    height: GLsizei,
+                                    format: GLenum,
+                                    data: &[u8]);
+    fn tex_image_3d(&self,
+                    target: GLenum,
+                    level: GLint,
+                    internal_format: GLint,
+                    width: GLsizei,
+                    height: GLsizei,
+                    depth: GLsizei,
+                    border: GLint,
+                    format: GLenum,
+                    ty: GLenum,
+                    opt_data: Option<&[u8]>);
+    fn copy_tex_image_2d(&self,
+                            target: GLenum,
+                            level: GLint,
+                            internal_format: GLenum,
+                            x: GLint,
+                            y: GLint,
+                            width: GLsizei,
+                            height: GLsizei,
+                            border: GLint);
+    fn copy_tex_sub_image_2d(&self,
+                                target: GLenum,
+                                level: GLint,
+                                xoffset: GLint,
+                                yoffset: GLint,
+                                x: GLint,
+                                y: GLint,
                                 width: GLsizei,
                                 height: GLsizei);
-        fn depth_func(&self, func: GLenum);
-        fn active_texture(&self, texture: GLenum);
-        fn attach_shader(&self, program: GLuint, shader: GLuint);
-        fn bind_attrib_location(&self, program: GLuint, index: GLuint, name: &str);
-        fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint>;
-        fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat>;
-        fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint;
-        fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint>;
-        fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint);
-        fn bind_buffer_range(&self, target: GLenum, index: GLuint, buffer: GLuint, offset: GLintptr, size: GLsizeiptr);
-        fn uniform_block_binding(&self,
-                                 program: GLuint,
-                                 uniform_block_index: GLuint,
-                                 uniform_block_binding: GLuint);
-        fn bind_buffer(&self, target: GLenum, buffer: GLuint);
-        fn bind_vertex_array(&self, vao: GLuint);
-        fn bind_renderbuffer(&self, target: GLenum, renderbuffer: GLuint);
-        fn bind_framebuffer(&self, target: GLenum, framebuffer: GLuint);
-        fn bind_texture(&self, target: GLenum, texture: GLuint);
-        fn draw_buffers(&self, bufs: &[GLenum]);
-        fn tex_image_2d(&self,
+    fn copy_tex_sub_image_3d(&self,
+                                target: GLenum,
+                                level: GLint,
+                                xoffset: GLint,
+                                yoffset: GLint,
+                                zoffset: GLint,
+                                x: GLint,
+                                y: GLint,
+                                width: GLsizei,
+                                height: GLsizei);
+    fn tex_sub_image_2d(&self,
                         target: GLenum,
                         level: GLint,
-                        internal_format: GLint,
+                        xoffset: GLint,
+                        yoffset: GLint,
                         width: GLsizei,
                         height: GLsizei,
-                        border: GLint,
                         format: GLenum,
                         ty: GLenum,
-                        opt_data: Option<&[u8]>);
-        fn compressed_tex_image_2d(&self,
-                                   target: GLenum,
-                                   level: GLint,
-                                   internal_format: GLenum,
-                                   width: GLsizei,
-                                   height: GLsizei,
-                                   border: GLint,
-                                   data: &[u8]);
-        fn compressed_tex_sub_image_2d(&self,
-                                       target: GLenum,
-                                       level: GLint,
-                                       xoffset: GLint,
-                                       yoffset: GLint,
-                                       width: GLsizei,
-                                       height: GLsizei,
-                                       format: GLenum,
-                                       data: &[u8]);
-        fn tex_image_3d(&self,
-                        target: GLenum,
-                        level: GLint,
-                        internal_format: GLint,
-                        width: GLsizei,
-                        height: GLsizei,
-                        depth: GLsizei,
-                        border: GLint,
-                        format: GLenum,
-                        ty: GLenum,
-                        opt_data: Option<&[u8]>);
-        fn copy_tex_image_2d(&self,
-                             target: GLenum,
-                             level: GLint,
-                             internal_format: GLenum,
-                             x: GLint,
-                             y: GLint,
-                             width: GLsizei,
-                             height: GLsizei,
-                             border: GLint);
-        fn copy_tex_sub_image_2d(&self,
-                                 target: GLenum,
-                                 level: GLint,
-                                 xoffset: GLint,
-                                 yoffset: GLint,
-                                 x: GLint,
-                                 y: GLint,
-                                 width: GLsizei,
-                                 height: GLsizei);
-        fn copy_tex_sub_image_3d(&self,
-                                 target: GLenum,
-                                 level: GLint,
-                                 xoffset: GLint,
-                                 yoffset: GLint,
-                                 zoffset: GLint,
-                                 x: GLint,
-                                 y: GLint,
-                                 width: GLsizei,
-                                 height: GLsizei);
-        fn tex_sub_image_2d(&self,
+                        data: &[u8]);
+    fn tex_sub_image_2d_pbo(&self,
                             target: GLenum,
                             level: GLint,
                             xoffset: GLint,
@@ -276,18 +286,20 @@ declare_gl_apis! {
                             height: GLsizei,
                             format: GLenum,
                             ty: GLenum,
-                            data: &[u8]);
-        fn tex_sub_image_2d_pbo(&self,
-                                target: GLenum,
-                                level: GLint,
-                                xoffset: GLint,
-                                yoffset: GLint,
-                                width: GLsizei,
-                                height: GLsizei,
-                                format: GLenum,
-                                ty: GLenum,
-                                offset: usize);
-        fn tex_sub_image_3d(&self,
+                            offset: usize);
+    fn tex_sub_image_3d(&self,
+                        target: GLenum,
+                        level: GLint,
+                        xoffset: GLint,
+                        yoffset: GLint,
+                        zoffset: GLint,
+                        width: GLsizei,
+                        height: GLsizei,
+                        depth: GLsizei,
+                        format: GLenum,
+                        ty: GLenum,
+                        data: &[u8]);
+    fn tex_sub_image_3d_pbo(&self,
                             target: GLenum,
                             level: GLint,
                             xoffset: GLint,
@@ -298,242 +310,224 @@ declare_gl_apis! {
                             depth: GLsizei,
                             format: GLenum,
                             ty: GLenum,
-                            data: &[u8]);
-        fn tex_sub_image_3d_pbo(&self,
+                            offset: usize);
+    fn get_tex_image_into_buffer(&self,
                                 target: GLenum,
                                 level: GLint,
-                                xoffset: GLint,
-                                yoffset: GLint,
-                                zoffset: GLint,
-                                width: GLsizei,
-                                height: GLsizei,
-                                depth: GLsizei,
                                 format: GLenum,
                                 ty: GLenum,
-                                offset: usize);
-        fn get_tex_image_into_buffer(&self,
+                                output: &mut [u8]);
+
+    unsafe fn get_integer_v(&self, name: GLenum, result: &mut [GLint]);
+    unsafe fn get_integer_64v(&self, name: GLenum, result: &mut [GLint64]);
+    unsafe fn get_integer_iv(&self, name: GLenum, index: GLuint, result: &mut [GLint]);
+    unsafe fn get_integer_64iv(&self, name: GLenum, index: GLuint, result: &mut [GLint64]);
+    unsafe fn get_boolean_v(&self, name: GLenum, result: &mut [GLboolean]);
+    unsafe fn get_float_v(&self, name: GLenum, result: &mut [GLfloat]);
+
+    fn get_framebuffer_attachment_parameter_iv(&self,
+                                            target: GLenum,
+                                            attachment: GLenum,
+                                            pname: GLenum) -> GLint;
+    fn get_renderbuffer_parameter_iv(&self,
                                      target: GLenum,
-                                     level: GLint,
-                                     format: GLenum,
-                                     ty: GLenum,
-                                     output: &mut [u8]);
-        fn get_integer_v(&self, name: GLenum) -> GLint;
-        fn get_integer_64v(&self, name: GLenum) -> GLint64;
-        fn get_integer_iv(&self, name: GLenum, index: GLuint) -> GLint;
-        fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64;
-        fn get_boolean_v(&self, name: GLenum) -> GLboolean;
-        fn get_float_v(&self, name: GLenum) -> GLfloat;
-        fn get_framebuffer_attachment_parameter_iv(&self,
-                                                   target: GLenum,
-                                                   attachment: GLenum,
-                                                   pname: GLenum) -> GLint;
-        fn get_renderbuffer_parameter_iv(&self,
-                                         target: GLenum,
-                                         pname: GLenum) -> GLint;
-        fn get_tex_parameter_iv(&self, target: GLenum, name: GLenum) -> GLint;
-        fn get_tex_parameter_fv(&self, target: GLenum, name: GLenum) -> GLfloat;
-        fn tex_parameter_i(&self, target: GLenum, pname: GLenum, param: GLint);
-        fn tex_parameter_f(&self, target: GLenum, pname: GLenum, param: GLfloat);
-        fn framebuffer_texture_2d(&self,
-                                  target: GLenum,
-                                  attachment: GLenum,
-                                  textarget: GLenum,
-                                  texture: GLuint,
-                                  level: GLint);
-        fn framebuffer_texture_layer(&self,
-                                     target: GLenum,
-                                     attachment: GLenum,
-                                     texture: GLuint,
-                                     level: GLint,
-                                     layer: GLint);
-        fn blit_framebuffer(&self,
-                            src_x0: GLint,
-                            src_y0: GLint,
-                            src_x1: GLint,
-                            src_y1: GLint,
-                            dst_x0: GLint,
-                            dst_y0: GLint,
-                            dst_x1: GLint,
-                            dst_y1: GLint,
-                            mask: GLbitfield,
-                            filter: GLenum);
-        fn vertex_attrib_4f(&self, index: GLuint, x: GLfloat, y: GLfloat, z: GLfloat, w: GLfloat);
-        fn vertex_attrib_pointer_f32(&self,
-                                     index: GLuint,
-                                     size: GLint,
-                                     normalized: bool,
-                                     stride: GLsizei,
-                                     offset: GLuint);
-        fn vertex_attrib_pointer(&self,
-                                 index: GLuint,
-                                 size: GLint,
-                                 type_: GLenum,
-                                 normalized: bool,
-                                 stride: GLsizei,
-                                 offset: GLuint);
-        fn vertex_attrib_i_pointer(&self,
-                                   index: GLuint,
-                                   size: GLint,
-                                   type_: GLenum,
-                                   stride: GLsizei,
-                                   offset: GLuint);
-        fn vertex_attrib_divisor(&self, index: GLuint, divisor: GLuint);
-        fn viewport(&self, x: GLint, y: GLint, width: GLsizei, height: GLsizei);
-        fn get_viewport(&self) -> (GLint, GLint, GLsizei, GLsizei);
-        fn scissor(&self, x: GLint, y: GLint, width: GLsizei, height: GLsizei);
-        fn line_width(&self, width: GLfloat);
-        fn use_program(&self, program: GLuint);
-        fn validate_program(&self, program: GLuint);
-        fn draw_arrays(&self, mode: GLenum, first: GLint, count: GLsizei);
-        fn draw_arrays_instanced(&self,
-                                 mode: GLenum,
-                                 first: GLint,
-                                 count: GLsizei,
-                                 primcount: GLsizei);
-        fn draw_elements(&self,
-                         mode: GLenum,
-                         count: GLsizei,
-                         element_type: GLenum,
-                         indices_offset: GLuint);
-        fn draw_elements_instanced(&self,
-                                   mode: GLenum,
-                                   count: GLsizei,
-                                   element_type: GLenum,
-                                   indices_offset: GLuint,
-                                   primcount: GLsizei);
-        fn blend_color(&self, r: f32, g: f32, b: f32, a: f32);
-        fn blend_func(&self, sfactor: GLenum, dfactor: GLenum);
-        fn blend_func_separate(&self,
-                               src_rgb: GLenum,
-                               dest_rgb: GLenum,
-                               src_alpha: GLenum,
-                               dest_alpha: GLenum);
-        fn blend_equation(&self, mode: GLenum);
-        fn blend_equation_separate(&self, mode_rgb: GLenum, mode_alpha: GLenum);
-        fn color_mask(&self, r: bool, g: bool, b: bool, a: bool);
-        fn cull_face(&self, mode: GLenum);
-        fn front_face(&self, mode: GLenum);
-        fn enable(&self, cap: GLenum);
-        fn disable(&self, cap: GLenum);
-        fn hint(&self, param_name: GLenum, param_val: GLenum);
-        fn is_enabled(&self, cap: GLenum) -> GLboolean;
-        fn is_shader(&self, shader: GLuint) -> GLboolean;
-        fn is_texture(&self, texture: GLenum) -> GLboolean;
-        fn is_framebuffer(&self, framebuffer: GLenum) -> GLboolean;
-        fn is_renderbuffer(&self, renderbuffer: GLenum) -> GLboolean;
-        fn check_frame_buffer_status(&self, target: GLenum) -> GLenum;
-        fn enable_vertex_attrib_array(&self, index: GLuint);
-        fn disable_vertex_attrib_array(&self, index: GLuint);
-        fn uniform_1f(&self, location: GLint, v0: GLfloat);
-        fn uniform_1fv(&self, location: GLint, values: &[f32]);
-        fn uniform_1i(&self, location: GLint, v0: GLint);
-        fn uniform_1iv(&self, location: GLint, values: &[i32]);
-        fn uniform_1ui(&self, location: GLint, v0: GLuint);
-        fn uniform_2f(&self, location: GLint, v0: GLfloat, v1: GLfloat);
-        fn uniform_2fv(&self, location: GLint, values: &[f32]);
-        fn uniform_2i(&self, location: GLint, v0: GLint, v1: GLint);
-        fn uniform_2iv(&self, location: GLint, values: &[i32]);
-        fn uniform_2ui(&self, location: GLint, v0: GLuint, v1: GLuint);
-        fn uniform_3f(&self, location: GLint, v0: GLfloat, v1: GLfloat, v2: GLfloat);
-        fn uniform_3fv(&self, location: GLint, values: &[f32]);
-        fn uniform_3i(&self, location: GLint, v0: GLint, v1: GLint, v2: GLint);
-        fn uniform_3iv(&self, location: GLint, values: &[i32]);
-        fn uniform_3ui(&self, location: GLint, v0: GLuint, v1: GLuint, v2: GLuint);
-        fn uniform_4f(&self, location: GLint, x: GLfloat, y: GLfloat, z: GLfloat, w: GLfloat);
-        fn uniform_4i(&self, location: GLint, x: GLint, y: GLint, z: GLint, w: GLint);
-        fn uniform_4iv(&self, location: GLint, values: &[i32]);
-        fn uniform_4ui(&self, location: GLint, x: GLuint, y: GLuint, z: GLuint, w: GLuint);
-        fn uniform_4fv(&self, location: GLint, values: &[f32]);
-        fn uniform_matrix_2fv(&self, location: GLint, transpose: bool, value: &[f32]);
-        fn uniform_matrix_3fv(&self, location: GLint, transpose: bool, value: &[f32]);
-        fn uniform_matrix_4fv(&self, location: GLint, transpose: bool, value: &[f32]);
-        fn depth_mask(&self, flag: bool);
-        fn depth_range(&self, near: f64, far: f64);
-        fn get_active_attrib(&self, program: GLuint, index: GLuint) -> (i32, u32, String);
-        fn get_active_uniform(&self, program: GLuint, index: GLuint) -> (i32, u32, String);
-        fn get_active_uniforms_iv(&self, program: GLuint, indices: Vec<GLuint>, pname: GLenum) -> Vec<GLint>;
-        fn get_active_uniform_block_i(&self, program: GLuint, index: GLuint, pname: GLenum) -> GLint;
-        fn get_active_uniform_block_iv(&self, program: GLuint, index: GLuint, pname: GLenum) -> Vec<GLint>;
-        fn get_active_uniform_block_name(&self, program: GLuint, index: GLuint) -> String;
-        fn get_attrib_location(&self, program: GLuint, name: &str) -> c_int;
-        fn get_frag_data_location(&self, program: GLuint, name: &str) -> c_int;
-        fn get_uniform_location(&self, program: GLuint, name: &str) -> c_int;
-        fn get_program_info_log(&self, program: GLuint) -> String;
-        fn get_program_iv(&self, program: GLuint, pname: GLenum) -> GLint;
-        fn get_program_binary(&self, program: GLuint) -> (Vec<u8>, GLenum);
-        fn program_binary(&self, program: GLuint, format: GLenum, binary: &[u8]);
-        fn program_parameter_i(&self, program: GLuint, pname: GLenum, value: GLint);
-        fn get_vertex_attrib_iv(&self, index: GLuint, pname: GLenum) -> GLint;
-        fn get_vertex_attrib_fv(&self, index: GLuint, pname: GLenum) -> Vec<GLfloat>;
-        fn get_vertex_attrib_pointer_v(&self, index: GLuint, pname: GLenum) -> GLsizeiptr;
-        fn get_buffer_parameter_iv(&self, target: GLuint, pname: GLenum) -> GLint;
-        fn get_shader_info_log(&self, shader: GLuint) -> String;
-        fn get_string(&self, which: GLenum) -> String;
-        fn get_string_i(&self, which: GLenum, index: GLuint) -> String;
-        fn get_shader_iv(&self, shader: GLuint, pname: GLenum) -> GLint;
-        fn get_shader_precision_format(&self,
-                                       shader_type: GLuint,
-                                       precision_type: GLuint)
-                                       -> (GLint, GLint, GLint);
-        fn compile_shader(&self, shader: GLuint);
-        fn create_program(&self) -> GLuint;
-        fn delete_program(&self, program: GLuint);
-        fn create_shader(&self, shader_type: GLenum) -> GLuint;
-        fn delete_shader(&self, shader: GLuint);
-        fn detach_shader(&self, program: GLuint, shader: GLuint);
-        fn link_program(&self, program: GLuint);
-        fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
-        fn clear(&self, buffer_mask: GLbitfield);
-        fn clear_depth(&self, depth: f64);
-        fn clear_stencil(&self, s: GLint);
-        fn flush(&self);
-        fn finish(&self);
-        fn get_error(&self) -> GLenum;
-        fn stencil_mask(&self, mask: GLuint);
-        fn stencil_mask_separate(&self, face: GLenum, mask: GLuint);
-        fn stencil_func(&self, func: GLenum, ref_: GLint, mask: GLuint);
-        fn stencil_func_separate(&self, face: GLenum, func: GLenum, ref_: GLint, mask: GLuint);
-        fn stencil_op(&self, sfail: GLenum, dpfail: GLenum, dppass: GLenum);
-        fn stencil_op_separate(&self, face: GLenum, sfail: GLenum, dpfail: GLenum, dppass: GLenum);
-        fn egl_image_target_texture2d_oes(&self, target: GLenum, image: GLeglImageOES);
-        fn generate_mipmap(&self, target: GLenum);
-        fn insert_event_marker_ext(&self, message: &str);
-        fn push_group_marker_ext(&self, message: &str);
-        fn pop_group_marker_ext(&self);
-        fn fence_sync(&self, condition: GLenum, flags: GLbitfield) -> GLsync;
-        fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64);
-        fn wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64);
-        fn delete_sync(&self, sync: GLsync);
-        fn texture_range_apple(&self, target: GLenum, data: &[u8]);
-        fn gen_fences_apple(&self, n: GLsizei) -> Vec<GLuint>;
-        fn delete_fences_apple(&self, fences: &[GLuint]);
-        fn set_fence_apple(&self, fence: GLuint);
-        fn finish_fence_apple(&self, fence: GLuint);
-        fn test_fence_apple(&self, fence: GLuint);
+                                     pname: GLenum) -> GLint;
+    fn get_tex_parameter_iv(&self, target: GLenum, name: GLenum) -> GLint;
+    fn get_tex_parameter_fv(&self, target: GLenum, name: GLenum) -> GLfloat;
+    fn tex_parameter_i(&self, target: GLenum, pname: GLenum, param: GLint);
+    fn tex_parameter_f(&self, target: GLenum, pname: GLenum, param: GLfloat);
+    fn framebuffer_texture_2d(&self,
+                                target: GLenum,
+                                attachment: GLenum,
+                                textarget: GLenum,
+                                texture: GLuint,
+                                level: GLint);
+    fn framebuffer_texture_layer(&self,
+                                    target: GLenum,
+                                    attachment: GLenum,
+                                    texture: GLuint,
+                                    level: GLint,
+                                    layer: GLint);
+    fn blit_framebuffer(&self,
+                        src_x0: GLint,
+                        src_y0: GLint,
+                        src_x1: GLint,
+                        src_y1: GLint,
+                        dst_x0: GLint,
+                        dst_y0: GLint,
+                        dst_x1: GLint,
+                        dst_y1: GLint,
+                        mask: GLbitfield,
+                        filter: GLenum);
+    fn vertex_attrib_4f(&self, index: GLuint, x: GLfloat, y: GLfloat, z: GLfloat, w: GLfloat);
+    fn vertex_attrib_pointer_f32(&self,
+                                    index: GLuint,
+                                    size: GLint,
+                                    normalized: bool,
+                                    stride: GLsizei,
+                                    offset: GLuint);
+    fn vertex_attrib_pointer(&self,
+                            index: GLuint,
+                            size: GLint,
+                            type_: GLenum,
+                            normalized: bool,
+                            stride: GLsizei,
+                            offset: GLuint);
+    fn vertex_attrib_i_pointer(&self,
+                            index: GLuint,
+                            size: GLint,
+                            type_: GLenum,
+                            stride: GLsizei,
+                            offset: GLuint);
+    fn vertex_attrib_divisor(&self, index: GLuint, divisor: GLuint);
+    fn viewport(&self, x: GLint, y: GLint, width: GLsizei, height: GLsizei);
+    fn scissor(&self, x: GLint, y: GLint, width: GLsizei, height: GLsizei);
+    fn line_width(&self, width: GLfloat);
+    fn use_program(&self, program: GLuint);
+    fn validate_program(&self, program: GLuint);
+    fn draw_arrays(&self, mode: GLenum, first: GLint, count: GLsizei);
+    fn draw_arrays_instanced(&self,
+                            mode: GLenum,
+                            first: GLint,
+                            count: GLsizei,
+                            primcount: GLsizei);
+    fn draw_elements(&self,
+                    mode: GLenum,
+                    count: GLsizei,
+                    element_type: GLenum,
+                    indices_offset: GLuint);
+    fn draw_elements_instanced(&self,
+                            mode: GLenum,
+                            count: GLsizei,
+                            element_type: GLenum,
+                            indices_offset: GLuint,
+                            primcount: GLsizei);
+    fn blend_color(&self, r: f32, g: f32, b: f32, a: f32);
+    fn blend_func(&self, sfactor: GLenum, dfactor: GLenum);
+    fn blend_func_separate(&self,
+                        src_rgb: GLenum,
+                        dest_rgb: GLenum,
+                        src_alpha: GLenum,
+                        dest_alpha: GLenum);
+    fn blend_equation(&self, mode: GLenum);
+    fn blend_equation_separate(&self, mode_rgb: GLenum, mode_alpha: GLenum);
+    fn color_mask(&self, r: bool, g: bool, b: bool, a: bool);
+    fn cull_face(&self, mode: GLenum);
+    fn front_face(&self, mode: GLenum);
+    fn enable(&self, cap: GLenum);
+    fn disable(&self, cap: GLenum);
+    fn hint(&self, param_name: GLenum, param_val: GLenum);
+    fn is_enabled(&self, cap: GLenum) -> GLboolean;
+    fn is_shader(&self, shader: GLuint) -> GLboolean;
+    fn is_texture(&self, texture: GLenum) -> GLboolean;
+    fn is_framebuffer(&self, framebuffer: GLenum) -> GLboolean;
+    fn is_renderbuffer(&self, renderbuffer: GLenum) -> GLboolean;
+    fn check_frame_buffer_status(&self, target: GLenum) -> GLenum;
+    fn enable_vertex_attrib_array(&self, index: GLuint);
+    fn disable_vertex_attrib_array(&self, index: GLuint);
+    fn uniform_1f(&self, location: GLint, v0: GLfloat);
+    fn uniform_1fv(&self, location: GLint, values: &[f32]);
+    fn uniform_1i(&self, location: GLint, v0: GLint);
+    fn uniform_1iv(&self, location: GLint, values: &[i32]);
+    fn uniform_1ui(&self, location: GLint, v0: GLuint);
+    fn uniform_2f(&self, location: GLint, v0: GLfloat, v1: GLfloat);
+    fn uniform_2fv(&self, location: GLint, values: &[f32]);
+    fn uniform_2i(&self, location: GLint, v0: GLint, v1: GLint);
+    fn uniform_2iv(&self, location: GLint, values: &[i32]);
+    fn uniform_2ui(&self, location: GLint, v0: GLuint, v1: GLuint);
+    fn uniform_3f(&self, location: GLint, v0: GLfloat, v1: GLfloat, v2: GLfloat);
+    fn uniform_3fv(&self, location: GLint, values: &[f32]);
+    fn uniform_3i(&self, location: GLint, v0: GLint, v1: GLint, v2: GLint);
+    fn uniform_3iv(&self, location: GLint, values: &[i32]);
+    fn uniform_3ui(&self, location: GLint, v0: GLuint, v1: GLuint, v2: GLuint);
+    fn uniform_4f(&self, location: GLint, x: GLfloat, y: GLfloat, z: GLfloat, w: GLfloat);
+    fn uniform_4i(&self, location: GLint, x: GLint, y: GLint, z: GLint, w: GLint);
+    fn uniform_4iv(&self, location: GLint, values: &[i32]);
+    fn uniform_4ui(&self, location: GLint, x: GLuint, y: GLuint, z: GLuint, w: GLuint);
+    fn uniform_4fv(&self, location: GLint, values: &[f32]);
+    fn uniform_matrix_2fv(&self, location: GLint, transpose: bool, value: &[f32]);
+    fn uniform_matrix_3fv(&self, location: GLint, transpose: bool, value: &[f32]);
+    fn uniform_matrix_4fv(&self, location: GLint, transpose: bool, value: &[f32]);
+    fn depth_mask(&self, flag: bool);
+    fn depth_range(&self, near: f64, far: f64);
+    fn get_active_attrib(&self, program: GLuint, index: GLuint) -> (i32, u32, String);
+    fn get_active_uniform(&self, program: GLuint, index: GLuint) -> (i32, u32, String);
+    fn get_active_uniforms_iv(&self, program: GLuint, indices: Vec<GLuint>, pname: GLenum) -> Vec<GLint>;
+    fn get_active_uniform_block_i(&self, program: GLuint, index: GLuint, pname: GLenum) -> GLint;
+    fn get_active_uniform_block_iv(&self, program: GLuint, index: GLuint, pname: GLenum) -> Vec<GLint>;
+    fn get_active_uniform_block_name(&self, program: GLuint, index: GLuint) -> String;
+    fn get_attrib_location(&self, program: GLuint, name: &str) -> c_int;
+    fn get_frag_data_location(&self, program: GLuint, name: &str) -> c_int;
+    fn get_uniform_location(&self, program: GLuint, name: &str) -> c_int;
+    fn get_program_info_log(&self, program: GLuint) -> String;
+    unsafe fn get_program_iv(&self, program: GLuint, pname: GLenum, result: &mut [GLint]);
+    fn get_program_binary(&self, program: GLuint) -> (Vec<u8>, GLenum);
+    fn program_binary(&self, program: GLuint, format: GLenum, binary: &[u8]);
+    fn program_parameter_i(&self, program: GLuint, pname: GLenum, value: GLint);
+    unsafe fn get_vertex_attrib_iv(&self, index: GLuint, pname: GLenum, result: &mut [GLint]);
+    unsafe fn get_vertex_attrib_fv(&self, index: GLuint, pname: GLenum, result: &mut [GLfloat]);
+    fn get_vertex_attrib_pointer_v(&self, index: GLuint, pname: GLenum) -> GLsizeiptr;
+    fn get_buffer_parameter_iv(&self, target: GLuint, pname: GLenum) -> GLint;
+    fn get_shader_info_log(&self, shader: GLuint) -> String;
+    fn get_string(&self, which: GLenum) -> String;
+    fn get_string_i(&self, which: GLenum, index: GLuint) -> String;
+    unsafe fn get_shader_iv(&self, shader: GLuint, pname: GLenum, result: &mut [GLint]);
+    fn get_shader_precision_format(&self,
+                                shader_type: GLuint,
+                                precision_type: GLuint)
+                                -> (GLint, GLint, GLint);
+    fn compile_shader(&self, shader: GLuint);
+    fn create_program(&self) -> GLuint;
+    fn delete_program(&self, program: GLuint);
+    fn create_shader(&self, shader_type: GLenum) -> GLuint;
+    fn delete_shader(&self, shader: GLuint);
+    fn detach_shader(&self, program: GLuint, shader: GLuint);
+    fn link_program(&self, program: GLuint);
+    fn clear_color(&self, r: f32, g: f32, b: f32, a: f32);
+    fn clear(&self, buffer_mask: GLbitfield);
+    fn clear_depth(&self, depth: f64);
+    fn clear_stencil(&self, s: GLint);
+    fn flush(&self);
+    fn finish(&self);
+    fn get_error(&self) -> GLenum;
+    fn stencil_mask(&self, mask: GLuint);
+    fn stencil_mask_separate(&self, face: GLenum, mask: GLuint);
+    fn stencil_func(&self, func: GLenum, ref_: GLint, mask: GLuint);
+    fn stencil_func_separate(&self, face: GLenum, func: GLenum, ref_: GLint, mask: GLuint);
+    fn stencil_op(&self, sfail: GLenum, dpfail: GLenum, dppass: GLenum);
+    fn stencil_op_separate(&self, face: GLenum, sfail: GLenum, dpfail: GLenum, dppass: GLenum);
+    fn egl_image_target_texture2d_oes(&self, target: GLenum, image: GLeglImageOES);
+    fn generate_mipmap(&self, target: GLenum);
+    fn insert_event_marker_ext(&self, message: &str);
+    fn push_group_marker_ext(&self, message: &str);
+    fn pop_group_marker_ext(&self);
+    fn fence_sync(&self, condition: GLenum, flags: GLbitfield) -> GLsync;
+    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64);
+    fn wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64);
+    fn delete_sync(&self, sync: GLsync);
+    fn texture_range_apple(&self, target: GLenum, data: &[u8]);
+    fn gen_fences_apple(&self, n: GLsizei) -> Vec<GLuint>;
+    fn delete_fences_apple(&self, fences: &[GLuint]);
+    fn set_fence_apple(&self, fence: GLuint);
+    fn finish_fence_apple(&self, fence: GLuint);
+    fn test_fence_apple(&self, fence: GLuint);
 
-        // GL_ARB_blend_func_extended
-        fn bind_frag_data_location_indexed(
-            &self,
-            program: GLuint,
-            color_number: GLuint,
-            index: GLuint,
-            name: &str,
-        );
-        fn get_frag_data_index(
-            &self,
-            program: GLuint,
-            name: &str,
-        ) -> GLint;
+    // GL_ARB_blend_func_extended
+    fn bind_frag_data_location_indexed(
+        &self,
+        program: GLuint,
+        color_number: GLuint,
+        index: GLuint,
+        name: &str,
+    );
+    fn get_frag_data_index(
+        &self,
+        program: GLuint,
+        name: &str,
+    ) -> GLint;
 
-        fn alias_point_size_range(&self) -> (GLfloat, GLfloat);
-        fn alias_line_width_range(&self) -> (GLfloat, GLfloat);
-
-        // Returns the the maximum supported width and height of the viewport.
-        fn max_viewport_dims(&self) -> (GLint, GLint);
-
-        // GL_KHR_debug
-        fn get_debug_messages(&self) -> Vec<DebugMessage>;
-    }
+    // GL_KHR_debug
+    fn get_debug_messages(&self) -> Vec<DebugMessage>;
 }
 
 pub struct ErrorCheckingGl {

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -655,52 +655,40 @@ impl Gl for GlFns {
         }
     }
 
-    fn get_integer_v(&self, name: GLenum) -> GLint {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetIntegerv(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_v(&self, name: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetIntegerv(name, result.as_mut_ptr());
     }
 
-    fn get_integer_64v(&self, name: GLenum) -> GLint64 {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetInteger64v(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_64v(&self, name: GLenum, result: &mut [GLint64]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetInteger64v(name, result.as_mut_ptr());
     }
 
-    fn get_integer_iv(&self, name: GLenum, index: GLuint) -> GLint {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetIntegeri_v(name, index, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_iv(&self, name: GLenum, index: GLuint, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetIntegeri_v(name, index, result.as_mut_ptr());
     }
 
-    fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64 {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetInteger64i_v(name, index, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_64iv(&self, name: GLenum, index: GLuint, result: &mut [GLint64]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetInteger64i_v(name, index, result.as_mut_ptr());
     }
 
-    fn get_boolean_v(&self, name: GLenum) -> GLboolean {
-        let mut result = 0 as GLboolean;
-        unsafe {
-            self.ffi_gl_.GetBooleanv(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_boolean_v(&self, name: GLenum, result: &mut [GLboolean]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetBooleanv(name, result.as_mut_ptr());
     }
 
-    fn get_float_v(&self, name: GLenum) -> GLfloat {
-        let mut result = 0 as GLfloat;
-        unsafe {
-            self.ffi_gl_.GetFloatv(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_float_v(&self, name: GLenum, result: &mut [GLfloat]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetFloatv(name, result.as_mut_ptr());
     }
 
     fn get_framebuffer_attachment_parameter_iv(&self, target: GLenum, attachment: GLenum, pname: GLenum) -> GLint {
@@ -862,14 +850,6 @@ impl Gl for GlFns {
     fn viewport(&self, x: GLint, y: GLint, width: GLsizei, height: GLsizei) {
         unsafe {
             self.ffi_gl_.Viewport(x, y, width, height);
-        }
-    }
-
-    fn get_viewport(&self) -> (GLint, GLint, GLsizei, GLsizei) {
-        unsafe {
-            let mut ret = [0; 4];
-            self.ffi_gl_.GetIntegerv(ffi::VIEWPORT, ret.as_mut_ptr());
-            (ret[0], ret[1], ret[2], ret[3])
         }
     }
 
@@ -1220,28 +1200,49 @@ impl Gl for GlFns {
     }
 
     fn get_active_attrib(&self, program: GLuint, index: GLuint) -> (i32, u32, String) {
-        let buf_size = self.get_program_iv(program, ffi::ACTIVE_ATTRIBUTE_MAX_LENGTH);
-        let mut name = vec![0u8; buf_size as usize];
+        let mut buf_size = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::ACTIVE_ATTRIBUTE_MAX_LENGTH, &mut buf_size);
+        }
+        let mut name = vec![0u8; buf_size[0] as usize];
         let mut length = 0 as GLsizei;
         let mut size = 0 as i32;
         let mut type_ = 0 as u32;
         unsafe {
-            self.ffi_gl_.GetActiveAttrib(program, index, buf_size, &mut length, &mut size, &mut type_, name.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetActiveAttrib(
+                program,
+                index,
+                buf_size[0],
+                &mut length,
+                &mut size,
+                &mut type_,
+                name.as_mut_ptr() as *mut GLchar,
+            );
         }
         name.truncate(if length > 0 {length as usize} else {0});
         (size, type_, String::from_utf8(name).unwrap())
     }
 
     fn get_active_uniform(&self, program: GLuint, index: GLuint) -> (i32, u32, String) {
-        let buf_size = self.get_program_iv(program, ffi::ACTIVE_UNIFORM_MAX_LENGTH);
-        let mut name = vec![0 as u8; buf_size as usize];
+        let mut buf_size = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::ACTIVE_UNIFORM_MAX_LENGTH, &mut buf_size);
+        }
+        let mut name = vec![0 as u8; buf_size[0] as usize];
         let mut length: GLsizei = 0;
         let mut size: i32 = 0;
         let mut type_: u32 = 0;
 
         unsafe {
-            self.ffi_gl_.GetActiveUniform(program, index, buf_size, &mut length, &mut size,
-                                  &mut type_, name.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetActiveUniform(
+                program,
+                index,
+                buf_size[0],
+                &mut length,
+                &mut size,
+                &mut type_,
+                name.as_mut_ptr() as *mut GLchar,
+            );
         }
 
         name.truncate(if length > 0 { length as usize } else { 0 });
@@ -1318,47 +1319,55 @@ impl Gl for GlFns {
     }
 
     fn get_program_info_log(&self, program: GLuint) -> String {
-        let max_len = self.get_program_iv(program, ffi::INFO_LOG_LENGTH);
-        let mut result = vec![0u8; max_len as usize];
+        let mut max_len = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::INFO_LOG_LENGTH, &mut max_len);
+        }
+        let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;
         unsafe {
-            self.ffi_gl_.GetProgramInfoLog(program,
-                                           max_len as GLsizei,
-                                           &mut result_len,
-                                           result.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetProgramInfoLog(
+                program,
+                max_len[0] as GLsizei,
+                &mut result_len,
+                result.as_mut_ptr() as *mut GLchar,
+            );
         }
         result.truncate(if result_len > 0 {result_len as usize} else {0});
         String::from_utf8(result).unwrap()
     }
 
-    fn get_program_iv(&self, program: GLuint, pname: GLenum) -> GLint {
-        let mut result = 0 as GLint;
-        unsafe {
-            self.ffi_gl_.GetProgramiv(program, pname, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_program_iv(&self, program: GLuint, pname: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetProgramiv(program, pname, result.as_mut_ptr());
     }
 
     fn get_program_binary(&self, program: GLuint) -> (Vec<u8>, GLenum) {
         if !self.ffi_gl_.GetProgramBinary.is_loaded() {
             return (Vec::new(), NONE);
         }
-        let len = self.get_program_iv(program, ffi::PROGRAM_BINARY_LENGTH);
-        if len <= 0 {
+        let mut len = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::PROGRAM_BINARY_LENGTH, &mut len);
+        }
+        if len[0] <= 0 {
             return (Vec::new(), NONE);
         }
-        let mut binary: Vec<u8> = Vec::with_capacity(len as usize);
+        let mut binary: Vec<u8> = Vec::with_capacity(len[0] as usize);
         let mut format = NONE;
         let mut out_len = 0;
         unsafe {
-            binary.set_len(len as usize);
-            self.ffi_gl_.GetProgramBinary(program,
-                                          len,
-                                          &mut out_len as *mut GLsizei,
-                                          &mut format,
-                                          binary.as_mut_ptr() as *mut c_void);
+            binary.set_len(len[0] as usize);
+            self.ffi_gl_.GetProgramBinary(
+                program,
+                len[0],
+                &mut out_len as *mut GLsizei,
+                &mut format,
+                binary.as_mut_ptr() as *mut c_void,
+            );
         }
-        if len != out_len {
+        if len[0] != out_len {
             return (Vec::new(), NONE);
         }
 
@@ -1386,20 +1395,16 @@ impl Gl for GlFns {
         }
     }
 
-    fn get_vertex_attrib_iv(&self, index: GLuint, pname: GLenum) -> GLint {
-        let mut result = 0 as GLint;
-        unsafe {
-            self.ffi_gl_.GetVertexAttribiv(index, pname, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_vertex_attrib_iv(&self, index: GLuint, pname: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetVertexAttribiv(index, pname, result.as_mut_ptr());
     }
 
-    fn get_vertex_attrib_fv(&self, index: GLuint, pname: GLenum) -> Vec<GLfloat> {
-        let mut result = vec![0 as GLfloat; 4];
-        unsafe {
-            self.ffi_gl_.GetVertexAttribfv(index, pname, result.as_mut_ptr());
-        }
-        result
+    #[inline]
+    unsafe fn get_vertex_attrib_fv(&self, index: GLuint, pname: GLenum, result: &mut [GLfloat]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetVertexAttribfv(index, pname, result.as_mut_ptr());
     }
 
     fn get_vertex_attrib_pointer_v(&self, index: GLuint, pname: GLenum) -> GLsizeiptr {
@@ -1419,14 +1424,19 @@ impl Gl for GlFns {
     }
 
     fn get_shader_info_log(&self, shader: GLuint) -> String {
-        let max_len = self.get_shader_iv(shader, ffi::INFO_LOG_LENGTH);
-        let mut result = vec![0u8; max_len as usize];
+        let mut max_len = [0];
+        unsafe {
+            self.get_shader_iv(shader, ffi::INFO_LOG_LENGTH, &mut max_len);
+        }
+        let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;
         unsafe {
-            self.ffi_gl_.GetShaderInfoLog(shader,
-                                          max_len as GLsizei,
-                                          &mut result_len,
-                                          result.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetShaderInfoLog(
+                shader,
+                max_len[0] as GLsizei,
+                &mut result_len,
+                result.as_mut_ptr() as *mut GLchar,
+            );
         }
         result.truncate(if result_len > 0 {result_len as usize} else {0});
         String::from_utf8(result).unwrap()
@@ -1454,12 +1464,9 @@ impl Gl for GlFns {
         }
     }
 
-    fn get_shader_iv(&self, shader: GLuint, pname: GLenum) -> GLint {
-        let mut result = 0 as GLint;
-        unsafe {
-            self.ffi_gl_.GetShaderiv(shader, pname, &mut result);
-        }
-        result
+    unsafe fn get_shader_iv(&self, shader: GLuint, pname: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetShaderiv(shader, pname, result.as_mut_ptr());
     }
 
     fn get_shader_precision_format(&self, _shader_type: GLuint, precision_type: GLuint) -> (GLint, GLint, GLint) {
@@ -1755,30 +1762,6 @@ impl Gl for GlFns {
                 program,
                 c_string.as_ptr(),
             )
-        }
-    }
-
-    fn alias_point_size_range(&self) -> (GLfloat, GLfloat) {
-        unsafe {
-            let mut ret = [0.; 2];
-            self.ffi_gl_.GetFloatv(ffi::ALIASED_POINT_SIZE_RANGE, ret.as_mut_ptr());
-            (ret[0], ret[1])
-        }
-    }
-
-    fn alias_line_width_range(&self) -> (GLfloat, GLfloat) {
-        unsafe {
-            let mut ret = [0.; 2];
-            self.ffi_gl_.GetFloatv(ffi::ALIASED_LINE_WIDTH_RANGE, ret.as_mut_ptr());
-            (ret[0], ret[1])
-        }
-    }
-
-    fn max_viewport_dims(&self) -> (GLint, GLint) {
-        unsafe {
-            let mut ret = [0; 2];
-            self.ffi_gl_.GetIntegerv(ffi::MAX_VIEWPORT_DIMS, ret.as_mut_ptr());
-            (ret[0], ret[1])
         }
     }
 

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -674,53 +674,40 @@ impl Gl for GlesFns {
         panic!("not supported");
     }
 
-
-    fn get_integer_v(&self, name: GLenum) -> GLint {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetIntegerv(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_v(&self, name: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetIntegerv(name, result.as_mut_ptr());
     }
 
-    fn get_integer_64v(&self, name: GLenum) -> GLint64 {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetInteger64v(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_64v(&self, name: GLenum, result: &mut [GLint64]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetInteger64v(name, result.as_mut_ptr());
     }
 
-    fn get_integer_iv(&self, name: GLenum, index: GLuint) -> GLint {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetIntegeri_v(name, index, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_iv(&self, name: GLenum, index: GLuint, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetIntegeri_v(name, index, result.as_mut_ptr());
     }
 
-    fn get_integer_64iv(&self, name: GLenum, index: GLuint) -> GLint64 {
-        let mut result = 0;
-        unsafe {
-            self.ffi_gl_.GetInteger64i_v(name, index, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_integer_64iv(&self, name: GLenum, index: GLuint, result: &mut [GLint64]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetInteger64i_v(name, index, result.as_mut_ptr());
     }
 
-    fn get_boolean_v(&self, name: GLenum) -> GLboolean {
-        let mut result = 0 as GLboolean;
-        unsafe {
-            self.ffi_gl_.GetBooleanv(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_boolean_v(&self, name: GLenum, result: &mut [GLboolean]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetBooleanv(name, result.as_mut_ptr());
     }
 
-    fn get_float_v(&self, name: GLenum) -> GLfloat {
-        let mut result = 0 as GLfloat;
-        unsafe {
-            self.ffi_gl_.GetFloatv(name, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_float_v(&self, name: GLenum, result: &mut [GLfloat]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetFloatv(name, result.as_mut_ptr());
     }
 
     fn get_renderbuffer_parameter_iv(&self, target: GLenum, pname: GLenum) -> GLint {
@@ -882,14 +869,6 @@ impl Gl for GlesFns {
     fn viewport(&self, x: GLint, y: GLint, width: GLsizei, height: GLsizei) {
         unsafe {
             self.ffi_gl_.Viewport(x, y, width, height);
-        }
-    }
-
-    fn get_viewport(&self) -> (GLint, GLint, GLsizei, GLsizei) {
-        unsafe {
-            let mut ret = [0; 4];
-            self.ffi_gl_.GetIntegerv(ffi::VIEWPORT, ret.as_mut_ptr());
-            (ret[0], ret[1], ret[2], ret[3])
         }
     }
 
@@ -1236,28 +1215,49 @@ impl Gl for GlesFns {
     }
 
     fn get_active_attrib(&self, program: GLuint, index: GLuint) -> (i32, u32, String) {
-        let buf_size = self.get_program_iv(program, ffi::ACTIVE_ATTRIBUTE_MAX_LENGTH);
-        let mut name = vec![0u8; buf_size as usize];
+        let mut buf_size = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::ACTIVE_ATTRIBUTE_MAX_LENGTH, &mut buf_size);
+        }
+        let mut name = vec![0u8; buf_size[0] as usize];
         let mut length = 0 as GLsizei;
         let mut size = 0 as i32;
         let mut type_ = 0 as u32;
         unsafe {
-            self.ffi_gl_.GetActiveAttrib(program, index, buf_size, &mut length, &mut size, &mut type_, name.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetActiveAttrib(
+                program,
+                index,
+                buf_size[0],
+                &mut length,
+                &mut size,
+                &mut type_,
+                name.as_mut_ptr() as *mut GLchar,
+            );
         }
         name.truncate(if length > 0 {length as usize} else {0});
         (size, type_, String::from_utf8(name).unwrap())
     }
 
     fn get_active_uniform(&self, program: GLuint, index: GLuint) -> (i32, u32, String) {
-        let buf_size = self.get_program_iv(program, ffi::ACTIVE_UNIFORM_MAX_LENGTH);
-        let mut name = vec![0 as u8; buf_size as usize];
+        let mut buf_size = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::ACTIVE_UNIFORM_MAX_LENGTH, &mut buf_size);
+        }
+        let mut name = vec![0 as u8; buf_size[0] as usize];
         let mut length: GLsizei = 0;
         let mut size: i32 = 0;
         let mut type_: u32 = 0;
 
         unsafe {
-            self.ffi_gl_.GetActiveUniform(program, index, buf_size, &mut length, &mut size,
-                                  &mut type_, name.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetActiveUniform(
+                program,
+                index,
+                buf_size[0],
+                &mut length,
+                &mut size,
+                &mut type_,
+                name.as_mut_ptr() as *mut GLchar,
+            );
         }
 
         name.truncate(if length > 0 { length as usize } else { 0 });
@@ -1332,44 +1332,52 @@ impl Gl for GlesFns {
     }
 
     fn get_program_info_log(&self, program: GLuint) -> String {
-        let max_len = self.get_program_iv(program, ffi::INFO_LOG_LENGTH);
-        let mut result = vec![0u8; max_len as usize];
+        let mut max_len = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::INFO_LOG_LENGTH, &mut max_len);
+        }
+        let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;
         unsafe {
-            self.ffi_gl_.GetProgramInfoLog(program,
-                                           max_len as GLsizei,
-                                           &mut result_len,
-                                           result.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetProgramInfoLog(
+                program,
+                max_len[0] as GLsizei,
+                &mut result_len,
+                result.as_mut_ptr() as *mut GLchar,
+            );
         }
         result.truncate(if result_len > 0 {result_len as usize} else {0});
         String::from_utf8(result).unwrap()
     }
 
-    fn get_program_iv(&self, program: GLuint, pname: GLenum) -> GLint {
-        let mut result = 0 as GLint;
-        unsafe {
-            self.ffi_gl_.GetProgramiv(program, pname, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_program_iv(&self, program: GLuint, pname: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetProgramiv(program, pname, result.as_mut_ptr());
     }
 
     fn get_program_binary(&self, program: GLuint) -> (Vec<u8>, GLenum) {
-        let len = self.get_program_iv(program, ffi::PROGRAM_BINARY_LENGTH);
-        if len <= 0 {
+        let mut len = [0];
+        unsafe {
+            self.get_program_iv(program, ffi::PROGRAM_BINARY_LENGTH, &mut len);
+        }
+        if len[0] <= 0 {
             return (Vec::new(), NONE);
         }
-        let mut binary: Vec<u8> = Vec::with_capacity(len as usize);
+        let mut binary: Vec<u8> = Vec::with_capacity(len[0] as usize);
         let mut format = NONE;
         let mut out_len = 0;
         unsafe {
-            binary.set_len(len as usize);
-            self.ffi_gl_.GetProgramBinary(program,
-                                          len,
-                                          &mut out_len as *mut GLsizei,
-                                          &mut format,
-                                          binary.as_mut_ptr() as *mut c_void);
+            binary.set_len(len[0] as usize);
+            self.ffi_gl_.GetProgramBinary(
+                program,
+                len[0],
+                &mut out_len as *mut GLsizei,
+                &mut format,
+                binary.as_mut_ptr() as *mut c_void,
+            );
         }
-        if len != out_len {
+        if len[0] != out_len {
             return (Vec::new(), NONE);
         }
 
@@ -1391,20 +1399,16 @@ impl Gl for GlesFns {
         }
     }
 
-    fn get_vertex_attrib_iv(&self, index: GLuint, pname: GLenum) -> GLint {
-        let mut result = 0 as GLint;
-        unsafe {
-            self.ffi_gl_.GetVertexAttribiv(index, pname, &mut result);
-        }
-        result
+    #[inline]
+    unsafe fn get_vertex_attrib_iv(&self, index: GLuint, pname: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetVertexAttribiv(index, pname, result.as_mut_ptr());
     }
 
-    fn get_vertex_attrib_fv(&self, index: GLuint, pname: GLenum) -> Vec<GLfloat> {
-        let mut result = vec![0 as GLfloat; 4];
-        unsafe {
-            self.ffi_gl_.GetVertexAttribfv(index, pname, result.as_mut_ptr());
-        }
-        result
+    #[inline]
+    unsafe fn get_vertex_attrib_fv(&self, index: GLuint, pname: GLenum, result: &mut [GLfloat]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetVertexAttribfv(index, pname, result.as_mut_ptr());
     }
 
     fn get_vertex_attrib_pointer_v(&self, index: GLuint, pname: GLenum) -> GLsizeiptr {
@@ -1424,14 +1428,19 @@ impl Gl for GlesFns {
     }
 
     fn get_shader_info_log(&self, shader: GLuint) -> String {
-        let max_len = self.get_shader_iv(shader, ffi::INFO_LOG_LENGTH);
-        let mut result = vec![0u8; max_len as usize];
+        let mut max_len = [0];
+        unsafe {
+            self.get_shader_iv(shader, ffi::INFO_LOG_LENGTH, &mut max_len);
+        }
+        let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;
         unsafe {
-            self.ffi_gl_.GetShaderInfoLog(shader,
-                                          max_len as GLsizei,
-                                          &mut result_len,
-                                          result.as_mut_ptr() as *mut GLchar);
+            self.ffi_gl_.GetShaderInfoLog(
+                shader,
+                max_len[0] as GLsizei,
+                &mut result_len,
+                result.as_mut_ptr() as *mut GLchar,
+            );
         }
         result.truncate(if result_len > 0 {result_len as usize} else {0});
         String::from_utf8(result).unwrap()
@@ -1459,12 +1468,9 @@ impl Gl for GlesFns {
         }
     }
 
-    fn get_shader_iv(&self, shader: GLuint, pname: GLenum) -> GLint {
-        let mut result = 0 as GLint;
-        unsafe {
-            self.ffi_gl_.GetShaderiv(shader, pname, &mut result);
-        }
-        result
+    unsafe fn get_shader_iv(&self, shader: GLuint, pname: GLenum, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetShaderiv(shader, pname, result.as_mut_ptr());
     }
 
     fn get_shader_precision_format(&self,
@@ -1717,30 +1723,6 @@ impl Gl for GlesFns {
         _name: &str,
     ) -> GLint {
         panic!("not supported");
-    }
-
-    fn alias_point_size_range(&self) -> (GLfloat, GLfloat) {
-        unsafe {
-            let mut ret = [0.; 2];
-            self.ffi_gl_.GetFloatv(ffi::ALIASED_POINT_SIZE_RANGE, ret.as_mut_ptr());
-            (ret[0], ret[1])
-        }
-    }
-
-    fn alias_line_width_range(&self) -> (GLfloat, GLfloat) {
-        unsafe {
-            let mut ret = [0.; 2];
-            self.ffi_gl_.GetFloatv(ffi::ALIASED_LINE_WIDTH_RANGE, ret.as_mut_ptr());
-            (ret[0], ret[1])
-        }
-    }
-
-    fn max_viewport_dims(&self) -> (GLint, GLint) {
-        unsafe {
-            let mut ret = [0; 2];
-            self.ffi_gl_.GetIntegerv(ffi::MAX_VIEWPORT_DIMS, ret.as_mut_ptr());
-            (ret[0], ret[1])
-        }
     }
 
     // GL_KHR_debug


### PR DESCRIPTION
We change get_boolean_iv etc to be unsafe and take a &mut [T] to write
the result into. We also take the opportunity to rename them to follow
more closely the naming of GL itself.

Fixes #151.
Fixes #153.
Fixes #154.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/164)
<!-- Reviewable:end -->
