### PR TITLE
Make get_uniform_iv and get_uniform_fv unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.5.1"
+version = "0.6.0"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -62,37 +62,6 @@ fn calculate_length(width: GLsizei, height: GLsizei, format: GLenum, pixel_type:
     return (width * height * colors * depth) as usize;
 }
 
-// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-fn get_uniform_iv_vector_length(uniform_type: &GLuint) -> usize {
-    match *uniform_type {
-        ffi::BOOL |
-        ffi::INT |
-        ffi::SAMPLER_2D |
-        ffi::SAMPLER_CUBE => 1,
-        ffi::INT_VEC2 |
-        ffi::BOOL_VEC2 => 2,
-        ffi::INT_VEC3 |
-        ffi::BOOL_VEC3 => 3,
-        ffi::INT_VEC4 |
-        ffi::BOOL_VEC4 => 4,
-        _ => panic!("Invalid location argument"),
-    }
-}
-
-// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-fn get_uniform_fv_vector_length(uniform_type: &GLuint) -> usize {
-    match *uniform_type {
-        ffi::FLOAT => 1,
-        ffi::FLOAT_VEC2 => 2,
-        ffi::FLOAT_VEC3 => 3,
-        ffi::FLOAT_VEC4 |
-        ffi::FLOAT_MAT2 => 4,
-        ffi::FLOAT_MAT3 => 9,
-        ffi::FLOAT_MAT4 => 16,
-        _ => panic!("Invalid location argument"),
-    }
-}
-
 pub struct DebugMessage {
     pub message: String,
     pub source: GLenum,
@@ -185,8 +154,8 @@ declare_gl_apis! {
     fn active_texture(&self, texture: GLenum);
     fn attach_shader(&self, program: GLuint, shader: GLuint);
     fn bind_attrib_location(&self, program: GLuint, index: GLuint, name: &str);
-    fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint>;
-    fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat>;
+    unsafe fn get_uniform_iv(&self, program: GLuint, location: GLint, result: &mut [GLint]);
+    unsafe fn get_uniform_fv(&self, program: GLuint, location: GLint, result: &mut [GLfloat]);
     fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint;
     fn get_uniform_indices(&self,  program: GLuint, names: &[&str]) -> Vec<GLuint>;
     fn bind_buffer_base(&self, target: GLenum, index: GLuint, buffer: GLuint);

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -19,21 +19,6 @@ impl GlFns
             ffi_gl_: ffi_gl_,
         }) as Rc<Gl>
     }
-
-    fn get_active_uniform_type(&self, program: GLuint) -> GLuint {
-        let mut size: GLint = 0;
-        let mut uniform_type: GLuint = 0;
-        unsafe {
-            self.ffi_gl_.GetActiveUniform(program,
-                                          0 as GLuint,
-                                          0 as GLsizei,
-                                          ptr::null_mut(),
-                                          &mut size,
-                                          &mut uniform_type,
-                                          ptr::null_mut());
-        }
-        uniform_type
-    }
 }
 
 impl Gl for GlFns {
@@ -309,25 +294,15 @@ impl Gl for GlFns {
     }
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
-    fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint> {
-        let uniform_type = self.get_active_uniform_type(program);
-        let len = get_uniform_iv_vector_length(&uniform_type);
-        let mut result: [GLint; 4] = [0; 4];
-        unsafe {
-            self.ffi_gl_.GetUniformiv(program, location, result.as_mut_ptr());
-        }
-        Vec::from(&result[0..len])
+    unsafe fn get_uniform_iv(&self, program: GLuint, location: GLint, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetUniformiv(program, location, result.as_mut_ptr());
     }
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
-    fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat> {
-        let uniform_type = self.get_active_uniform_type(program);
-        let len = get_uniform_fv_vector_length(&uniform_type);
-        let mut result: [GLfloat; 16] = [0.0; 16];
-        unsafe {
-            self.ffi_gl_.GetUniformfv(program, location, result.as_mut_ptr());
-        }
-        Vec::from(&result[0..len])
+    unsafe fn get_uniform_fv(&self, program: GLuint, location: GLint, result: &mut [GLfloat]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetUniformfv(program, location, result.as_mut_ptr());
     }
 
     fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -19,21 +19,6 @@ impl GlesFns
             ffi_gl_: ffi_gl_,
         }) as Rc<Gl>
     }
-
-    fn get_active_uniform_type(&self, program: GLuint) -> GLuint {
-        let mut size: GLint = 0;
-        let mut uniform_type: GLuint = 0;
-        unsafe {
-            self.ffi_gl_.GetActiveUniform(program,
-                                          0 as GLuint,
-                                          0 as GLsizei,
-                                          ptr::null_mut(),
-                                          &mut size,
-                                          &mut uniform_type,
-                                          ptr::null_mut());
-        }
-        uniform_type
-    }
 }
 
 impl Gl for GlesFns {
@@ -333,25 +318,15 @@ impl Gl for GlesFns {
     }
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
-    fn get_uniform_iv(&self, program: GLuint, location: GLint) -> Vec<GLint> {
-        let uniform_type = self.get_active_uniform_type(program);
-        let len = get_uniform_iv_vector_length(&uniform_type);
-        let mut result: [GLint; 4] = [0; 4];
-        unsafe {
-            self.ffi_gl_.GetUniformiv(program, location, result.as_mut_ptr());
-        }
-        Vec::from(&result[0..len])
+    unsafe fn get_uniform_iv(&self, program: GLuint, location: GLint, result: &mut [GLint]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetUniformiv(program, location, result.as_mut_ptr());
     }
 
     // https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetUniform.xml
-    fn get_uniform_fv(&self, program: GLuint, location: GLint) -> Vec<GLfloat> {
-        let uniform_type = self.get_active_uniform_type(program);
-        let len = get_uniform_fv_vector_length(&uniform_type);
-        let mut result: [GLfloat; 16] = [0.0; 16];
-        unsafe {
-            self.ffi_gl_.GetUniformfv(program, location, result.as_mut_ptr());
-        }
-        Vec::from(&result[0..len])
+    unsafe fn get_uniform_fv(&self, program: GLuint, location: GLint, result: &mut [GLfloat]) {
+        assert!(!result.is_empty());
+        self.ffi_gl_.GetUniformfv(program, location, result.as_mut_ptr());
     }
 
     fn get_uniform_block_index(&self, program: GLuint, name: &str) -> GLuint {


### PR DESCRIPTION
They shouldn't check any uniform variable type by themselves, and the checks they did wasn't actually sound anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/170)
<!-- Reviewable:end -->
