### PR TITLE
Add R16 to the color formats for calculate_length.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.6.1"
+version = "0.6.2"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -49,6 +49,7 @@ fn calculate_length(width: GLsizei, height: GLsizei, format: GLenum, pixel_type:
         ffi::BGRA => 4,
 
         ffi::ALPHA => 1,
+        ffi::R16 => 1,
         ffi::LUMINANCE => 1,
         ffi::DEPTH_COMPONENT => 1,
         _ => panic!("unsupported format for read_pixels: {:?}", format),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/172)
<!-- Reviewable:end -->
