### PR TITLE
Use compatibility profile for OpenGL bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.6.3"
+version = "0.6.4"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,7 @@ fn main() {
         "GL_EXT_texture_filter_anisotropic",
         "GL_KHR_debug",
     ];
-    let gl_reg = Registry::new(Api::Gl, (3, 3), Profile::Core, Fallbacks::All, gl_extensions);
+    let gl_reg = Registry::new(Api::Gl, (3, 3), Profile::Compatibility, Fallbacks::All, gl_extensions);
     gl_reg.write_bindings(gl_generator::StructGenerator, &mut file_gl)
         .unwrap();
 


### PR DESCRIPTION
We need POINT_STRIPE in Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/174)
<!-- Reviewable:end -->
