### PR TITLE
Add support for glCopyImageSubData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.6.7"
+version = "0.6.8"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
         "GL_APPLE_fence",
         "GL_APPLE_texture_range",
         "GL_ARB_blend_func_extended",
+        "GL_ARB_copy_image",
         "GL_ARB_get_program_binary",
         "GL_ARB_invalidate_subdata",
         "GL_ARB_texture_rectangle",
@@ -31,6 +32,7 @@ fn main() {
 
     // GLES 3.0 bindings
     let gles_extensions = [
+        "GL_EXT_copy_image",
         "GL_EXT_debug_marker",
         "GL_EXT_disjoint_timer_query",
         "GL_EXT_shader_texture_lod",

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -302,6 +302,22 @@ declare_gl_apis! {
                                 format: GLenum,
                                 ty: GLenum,
                                 output: &mut [u8]);
+    unsafe fn copy_image_sub_data(&self,
+                                  src_name: GLuint,
+                                  src_target: GLenum,
+                                  src_level: GLint,
+                                  src_x: GLint,
+                                  src_y: GLint,
+                                  src_z: GLint,
+                                  dst_name: GLuint,
+                                  dst_target: GLenum,
+                                  dst_level: GLint,
+                                  dst_x: GLint,
+                                  dst_y: GLint,
+                                  dst_z: GLint,
+                                  src_width: GLsizei,
+                                  src_height: GLsizei,
+                                  src_depth: GLsizei);
 
     fn invalidate_framebuffer(&self,
                               target: GLenum,

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -667,6 +667,41 @@ impl Gl for GlFns {
         }
     }
 
+    unsafe fn copy_image_sub_data(&self,
+                                  src_name: GLuint,
+                                  src_target: GLenum,
+                                  src_level: GLint,
+                                  src_x: GLint,
+                                  src_y: GLint,
+                                  src_z: GLint,
+                                  dst_name: GLuint,
+                                  dst_target: GLenum,
+                                  dst_level: GLint,
+                                  dst_x: GLint,
+                                  dst_y: GLint,
+                                  dst_z: GLint,
+                                  src_width: GLsizei,
+                                  src_height: GLsizei,
+                                  src_depth: GLsizei) {
+        self.ffi_gl_.CopyImageSubData(
+            src_name,
+            src_target,
+            src_level,
+            src_x,
+            src_y,
+            src_z,
+            dst_name,
+            dst_target,
+            dst_level,
+            dst_x,
+            dst_y,
+            dst_z,
+            src_width,
+            src_height,
+            src_depth,
+        );
+    }
+
     fn invalidate_framebuffer(&self,
                               target: GLenum,
                               attachments: &[GLenum]) {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -681,6 +681,41 @@ impl Gl for GlesFns {
         panic!("not supported");
     }
 
+    unsafe fn copy_image_sub_data(&self,
+                                  src_name: GLuint,
+                                  src_target: GLenum,
+                                  src_level: GLint,
+                                  src_x: GLint,
+                                  src_y: GLint,
+                                  src_z: GLint,
+                                  dst_name: GLuint,
+                                  dst_target: GLenum,
+                                  dst_level: GLint,
+                                  dst_x: GLint,
+                                  dst_y: GLint,
+                                  dst_z: GLint,
+                                  src_width: GLsizei,
+                                  src_height: GLsizei,
+                                  src_depth: GLsizei) {
+        self.ffi_gl_.CopyImageSubDataEXT(
+            src_name,
+            src_target,
+            src_level,
+            src_x,
+            src_y,
+            src_z,
+            dst_name,
+            dst_target,
+            dst_level,
+            dst_x,
+            dst_y,
+            dst_z,
+            src_width,
+            src_height,
+            src_depth,
+        );
+    }
+
     fn invalidate_framebuffer(&self,
                               target: GLenum,
                               attachments: &[GLenum]) {


### PR DESCRIPTION
This will let us copy between textures quickly when growing the texture cache in webrender. (Especially on Adreno devices where glBlitFramebuffers and glCopyTexSubImage have issues with texture arrays - https://bugzilla.mozilla.org/show_bug.cgi?id=1505508)

Not sure if I've done this correctly so feedback welcome please. Especially in the generated gles_bindings.rs: the generated function has the EXT suffix. I found if I bumped the gles version to 3.2, then it dropped the suffix (since the function part of 3.2) but included the EXT version as a fallback. I'm not sure which is preferable.

I also wrapped the function calls in an "if is_loaded()". Is that the right thing to do? How is webrender code then meant to check if they're available? By checking for the extension?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/179)
<!-- Reviewable:end -->
