### PR TITLE
Work around a crash in some GL drivers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.6.10"
+version = "0.6.11"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -1594,6 +1594,9 @@ impl Gl for GlFns {
         unsafe {
             self.get_program_iv(program, ffi::INFO_LOG_LENGTH, &mut max_len);
         }
+        if max_len[0] == 0 {
+            return String::new();
+        }
         let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;
         unsafe {
@@ -1709,6 +1712,9 @@ impl Gl for GlFns {
         let mut max_len = [0];
         unsafe {
             self.get_shader_iv(shader, ffi::INFO_LOG_LENGTH, &mut max_len);
+        }
+        if max_len[0] == 0 {
+            return String::new();
         }
         let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -1604,6 +1604,9 @@ impl Gl for GlesFns {
         unsafe {
             self.get_program_iv(program, ffi::INFO_LOG_LENGTH, &mut max_len);
         }
+        if max_len[0] == 0 {
+            return String::new();
+        }
         let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;
         unsafe {
@@ -1710,6 +1713,9 @@ impl Gl for GlesFns {
         let mut max_len = [0];
         unsafe {
             self.get_shader_iv(shader, ffi::INFO_LOG_LENGTH, &mut max_len);
+        }
+        if max_len[0] == 0 {
+            return String::new();
         }
         let mut result = vec![0u8; max_len[0] as usize];
         let mut result_len = 0 as GLsizei;


### PR DESCRIPTION
When the Mali graphics debugger interceptor library is active,
calling glGetShaderInfoLog with a max length of 0 results in
a null pointer dereference and thus a crash inside the
intercept library.

We can work around this by early exiting from the log functions
if the reported log length is 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/185)
<!-- Reviewable:end -->
