### PR TITLE
Error callback wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.6.10"
+version = "0.6.11"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -87,6 +87,17 @@ macro_rules! declare_gl_apis {
                 rv
             })+
         }
+
+        impl<F: Fn(&Gl, &str, GLenum)> Gl for ErrorReactingGl<F> {
+            $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* {
+                let rv = self.gl.$name($($arg,)*);
+                let error = self.gl.get_error();
+                if error != 0 {
+                    (self.callback)(&*self.gl, stringify!($name), error);
+                }
+                rv
+            })+
+        }
     }
 }
 
@@ -550,6 +561,7 @@ declare_gl_apis! {
     fn get_debug_messages(&self) -> Vec<DebugMessage>;
 }
 
+//#[deprecated(since = "0.6.11", note = "use ErrorReactingGl instead")]
 pub struct ErrorCheckingGl {
     gl: Rc<Gl>,
 }
@@ -557,6 +569,18 @@ pub struct ErrorCheckingGl {
 impl ErrorCheckingGl {
     pub fn wrap(fns: Rc<Gl>) -> Rc<Gl> {
         Rc::new(ErrorCheckingGl { gl: fns }) as Rc<Gl>
+    }
+}
+
+/// A wrapper around GL context that calls a specified callback on each GL error.
+pub struct ErrorReactingGl<F> {
+    gl: Rc<Gl>,
+    callback: F,
+}
+
+impl<F: 'static + Fn(&Gl, &str, GLenum)> ErrorReactingGl<F> {
+    pub fn wrap(fns: Rc<Gl>, callback: F) -> Rc<Gl> {
+        Rc::new(ErrorReactingGl { gl: fns, callback }) as Rc<Gl>
     }
 }
 


### PR DESCRIPTION
The idea for this is to defer the decision to panic to the client of the library. They may prefer to ignore the errors up to the end of some scope of work, and to wrap things up nicely. Or they may query the driver for debug messages and panic with a more detailed report than just the error code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/186)
<!-- Reviewable:end -->
