### PR TITLE
Remove Rc usage from the crate

### DIFF
--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -12,12 +12,12 @@ pub struct GlFns {
 }
 
 impl GlFns {
-    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<Gl>
+    #[inline]
+    pub unsafe fn load_with<'a, F>(loadfn: F) -> Self
     where
         F: FnMut(&str) -> *const c_void,
     {
-        let ffi_gl_ = GlFfi::load_with(loadfn);
-        Rc::new(GlFns { ffi_gl_: ffi_gl_ }) as Rc<Gl>
+        Self { ffi_gl_: GlFfi::load_with(loadfn) }
     }
 }
 

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -12,12 +12,12 @@ pub struct GlesFns {
 }
 
 impl GlesFns {
-    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<Gl>
+    #[inline]
+    pub unsafe fn load_with<'a, F>(loadfn: F) -> Self
     where
         F: FnMut(&str) -> *const c_void,
     {
-        let ffi_gl_ = GlesFfi::load_with(loadfn);
-        Rc::new(GlesFns { ffi_gl_: ffi_gl_ }) as Rc<Gl>
+        Self { ffi_gl_: GlesFfi::load_with(loadfn) }
     }
 }
 


### PR DESCRIPTION

Callers should use Rc<T> wherever they want, so that adapters such as ErrorCheckingGl can do their job without multiple layers of virtual calls.