### PR TITLE
Support glMapBuffer where available

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -126,6 +126,9 @@ declare_gl_apis! {
                                 offset: isize,
                                 size: GLsizeiptr,
                                 data: *const GLvoid);
+    fn map_buffer(&self,
+                  target: GLenum,
+                  access: GLbitfield) -> *mut c_void;
     fn map_buffer_range(&self,
                         target: GLenum,
                         offset: GLintptr,

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -50,6 +50,14 @@ impl Gl for GlFns {
         }
     }
 
+    fn map_buffer(&self,
+                  target: GLenum,
+                  access: GLbitfield) -> *mut c_void {
+        unsafe {
+            return self.ffi_gl_.MapBuffer(target, access);
+        }
+    }
+
     fn map_buffer_range(&self,
                         target: GLenum,
                         offset: GLintptr,

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -54,6 +54,12 @@ impl Gl for GlesFns {
         }
     }
 
+    fn map_buffer(&self,
+                  _target: GLenum,
+                  _access: GLbitfield) -> *mut c_void {
+        panic!("not supported")
+    }
+
     fn map_buffer_range(&self,
                         target: GLenum,
                         offset: GLintptr,


### PR DESCRIPTION
Gleam currently supports glMapBufferRange, but that isn't available on
all platforms (e.g. macOS with a OpenGL Core profile). This patch adds
support for glMapBuffer only on GL profiles and panics on GLES profiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/190)
<!-- Reviewable:end -->
