### PR TITLE
Expose vertex array object extension API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.6.19"
+version = "0.6.20"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
         "GL_APPLE_client_storage",
         "GL_APPLE_fence",
         "GL_APPLE_texture_range",
+        "GL_APPLE_vertex_array_object",
         "GL_ARB_blend_func_extended",
         "GL_ARB_copy_image",
         "GL_ARB_get_program_binary",

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -169,6 +169,7 @@ declare_gl_apis! {
     fn gen_framebuffers(&self, n: GLsizei) -> Vec<GLuint>;
     fn gen_textures(&self, n: GLsizei) -> Vec<GLuint>;
     fn gen_vertex_arrays(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_vertex_arrays_apple(&self, n: GLsizei) -> Vec<GLuint>;
     fn gen_queries(&self, n: GLsizei) -> Vec<GLuint>;
     fn begin_query(&self, target: GLenum, id: GLuint);
     fn end_query(&self, target: GLenum);
@@ -179,6 +180,7 @@ declare_gl_apis! {
     fn get_query_object_ui64v(&self, id: GLuint, pname: GLenum) -> u64;
     fn delete_queries(&self, queries: &[GLuint]);
     fn delete_vertex_arrays(&self, vertex_arrays: &[GLuint]);
+    fn delete_vertex_arrays_apple(&self, vertex_arrays: &[GLuint]);
     fn delete_buffers(&self, buffers: &[GLuint]);
     fn delete_renderbuffers(&self, renderbuffers: &[GLuint]);
     fn delete_framebuffers(&self, framebuffers: &[GLuint]);
@@ -209,6 +211,7 @@ declare_gl_apis! {
                                 uniform_block_binding: GLuint);
     fn bind_buffer(&self, target: GLenum, buffer: GLuint);
     fn bind_vertex_array(&self, vao: GLuint);
+    fn bind_vertex_array_apple(&self, vao: GLuint);
     fn bind_renderbuffer(&self, target: GLenum, renderbuffer: GLuint);
     fn bind_framebuffer(&self, target: GLenum, framebuffer: GLuint);
     fn bind_texture(&self, target: GLenum, texture: GLuint);

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -89,7 +89,7 @@ macro_rules! declare_gl_apis {
             })+
         }
 
-        impl<F: Fn(&Gl, &str, GLenum)> Gl for ErrorReactingGl<F> {
+        impl<F: Fn(&dyn Gl, &str, GLenum)> Gl for ErrorReactingGl<F> {
             $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* {
                 let rv = self.gl.$name($($arg,)*);
                 let error = self.gl.get_error();
@@ -597,43 +597,43 @@ declare_gl_apis! {
 
 //#[deprecated(since = "0.6.11", note = "use ErrorReactingGl instead")]
 pub struct ErrorCheckingGl {
-    gl: Rc<Gl>,
+    gl: Rc<dyn Gl>,
 }
 
 impl ErrorCheckingGl {
-    pub fn wrap(fns: Rc<Gl>) -> Rc<Gl> {
-        Rc::new(ErrorCheckingGl { gl: fns }) as Rc<Gl>
+    pub fn wrap(fns: Rc<dyn Gl>) -> Rc<dyn Gl> {
+        Rc::new(ErrorCheckingGl { gl: fns }) as Rc<dyn Gl>
     }
 }
 
 /// A wrapper around GL context that calls a specified callback on each GL error.
 pub struct ErrorReactingGl<F> {
-    gl: Rc<Gl>,
+    gl: Rc<dyn Gl>,
     callback: F,
 }
 
-impl<F: 'static + Fn(&Gl, &str, GLenum)> ErrorReactingGl<F> {
-    pub fn wrap(fns: Rc<Gl>, callback: F) -> Rc<Gl> {
-        Rc::new(ErrorReactingGl { gl: fns, callback }) as Rc<Gl>
+impl<F: 'static + Fn(&dyn Gl, &str, GLenum)> ErrorReactingGl<F> {
+    pub fn wrap(fns: Rc<dyn Gl>, callback: F) -> Rc<dyn Gl> {
+        Rc::new(ErrorReactingGl { gl: fns, callback }) as Rc<dyn Gl>
     }
 }
 
 /// A wrapper around GL context that times each call and invokes the callback
 /// if the call takes longer than the threshold.
 pub struct ProfilingGl<F> {
-    gl: Rc<Gl>,
+    gl: Rc<dyn Gl>,
     threshold: Duration,
     callback: F,
 }
 
 impl<F: 'static + Fn(&str, Duration)> ProfilingGl<F> {
-    pub fn wrap(fns: Rc<Gl>, threshold: Duration, callback: F) -> Rc<Gl> {
-        Rc::new(ProfilingGl { gl: fns, threshold, callback }) as Rc<Gl>
+    pub fn wrap(fns: Rc<dyn Gl>, threshold: Duration, callback: F) -> Rc<dyn Gl> {
+        Rc::new(ProfilingGl { gl: fns, threshold, callback }) as Rc<dyn Gl>
     }
 }
 
 #[inline]
-pub fn buffer_data<T>(gl_: &Gl, target: GLenum, data: &[T], usage: GLenum) {
+pub fn buffer_data<T>(gl_: &dyn Gl, target: GLenum, data: &[T], usage: GLenum) {
     gl_.buffer_data_untyped(
         target,
         (data.len() * size_of::<T>()) as GLsizeiptr,
@@ -643,7 +643,7 @@ pub fn buffer_data<T>(gl_: &Gl, target: GLenum, data: &[T], usage: GLenum) {
 }
 
 #[inline]
-pub fn buffer_data_raw<T>(gl_: &Gl, target: GLenum, data: &T, usage: GLenum) {
+pub fn buffer_data_raw<T>(gl_: &dyn Gl, target: GLenum, data: &T, usage: GLenum) {
     gl_.buffer_data_untyped(
         target,
         size_of::<T>() as GLsizeiptr,
@@ -653,7 +653,7 @@ pub fn buffer_data_raw<T>(gl_: &Gl, target: GLenum, data: &T, usage: GLenum) {
 }
 
 #[inline]
-pub fn buffer_sub_data<T>(gl_: &Gl, target: GLenum, offset: isize, data: &[T]) {
+pub fn buffer_sub_data<T>(gl_: &dyn Gl, target: GLenum, offset: isize, data: &[T]) {
     gl_.buffer_sub_data_untyped(
         target,
         offset,

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -221,7 +221,15 @@ impl Gl for GlFns {
     fn gen_vertex_arrays(&self, n: GLsizei) -> Vec<GLuint> {
         let mut result = vec![0 as GLuint; n as usize];
         unsafe {
-            self.ffi_gl_.GenVertexArrays(n, result.as_mut_ptr());
+            self.ffi_gl_.GenVertexArrays(n, result.as_mut_ptr())
+        }
+        result
+    }
+
+    fn gen_vertex_arrays_apple(&self, n: GLsizei) -> Vec<GLuint> {
+        let mut result = vec![0 as GLuint; n as usize];
+        unsafe {
+            self.ffi_gl_.GenVertexArraysAPPLE(n, result.as_mut_ptr())
         }
         result
     }
@@ -295,6 +303,13 @@ impl Gl for GlFns {
         unsafe {
             self.ffi_gl_
                 .DeleteVertexArrays(vertex_arrays.len() as GLsizei, vertex_arrays.as_ptr());
+        }
+    }
+
+    fn delete_vertex_arrays_apple(&self, vertex_arrays: &[GLuint]) {
+        unsafe {
+            self.ffi_gl_
+                .DeleteVertexArraysAPPLE(vertex_arrays.len() as GLsizei, vertex_arrays.as_ptr());
         }
     }
 
@@ -461,6 +476,12 @@ impl Gl for GlFns {
     fn bind_vertex_array(&self, vao: GLuint) {
         unsafe {
             self.ffi_gl_.BindVertexArray(vao);
+        }
+    }
+
+    fn bind_vertex_array_apple(&self, vao: GLuint) {
+        unsafe {
+            self.ffi_gl_.BindVertexArrayAPPLE(vao)
         }
     }
 

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -12,12 +12,12 @@ pub struct GlFns {
 }
 
 impl GlFns {
-    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<Gl>
+    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<dyn Gl>
     where
         F: FnMut(&str) -> *const c_void,
     {
         let ffi_gl_ = GlFfi::load_with(loadfn);
-        Rc::new(GlFns { ffi_gl_: ffi_gl_ }) as Rc<Gl>
+        Rc::new(GlFns { ffi_gl_: ffi_gl_ }) as Rc<dyn Gl>
     }
 }
 

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -221,6 +221,10 @@ impl Gl for GlesFns {
         result
     }
 
+    fn gen_vertex_arrays_apple(&self, _n: GLsizei) -> Vec<GLuint> {
+        panic!("not supported")
+    }
+
     fn gen_queries(&self, n: GLsizei) -> Vec<GLuint> {
         if !self.ffi_gl_.GenQueriesEXT.is_loaded() {
             return Vec::new();
@@ -318,6 +322,10 @@ impl Gl for GlesFns {
             self.ffi_gl_
                 .DeleteVertexArrays(vertex_arrays.len() as GLsizei, vertex_arrays.as_ptr());
         }
+    }
+
+    fn delete_vertex_arrays_apple(&self, _vertex_arrays: &[GLuint]) {
+        panic!("not supported")
     }
 
     fn delete_buffers(&self, buffers: &[GLuint]) {
@@ -484,6 +492,10 @@ impl Gl for GlesFns {
         unsafe {
             self.ffi_gl_.BindVertexArray(vao);
         }
+    }
+
+    fn bind_vertex_array_apple(&self, _vao: GLuint) {
+        panic!("not supported")
     }
 
     fn bind_renderbuffer(&self, target: GLenum, renderbuffer: GLuint) {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -12,12 +12,12 @@ pub struct GlesFns {
 }
 
 impl GlesFns {
-    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<Gl>
+    pub unsafe fn load_with<'a, F>(loadfn: F) -> Rc<dyn Gl>
     where
         F: FnMut(&str) -> *const c_void,
     {
         let ffi_gl_ = GlesFfi::load_with(loadfn);
-        Rc::new(GlesFns { ffi_gl_: ffi_gl_ }) as Rc<Gl>
+        Rc::new(GlesFns { ffi_gl_: ffi_gl_ }) as Rc<dyn Gl>
     }
 }
 


### PR DESCRIPTION
This is needed in order to solve https://github.com/servo/servo/issues/23960. There's no way to transparently fall back to the APPLE method from the existing API because they are loaded in non-legacy GL contexts on macOS but point to the very unhelpful glInvalidFunction API and cause a crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/199)
<!-- Reviewable:end -->
