### PR TITLE
Add missing `is_query` function

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -473,6 +473,7 @@ declare_gl_apis! {
     fn disable(&self, cap: GLenum);
     fn hint(&self, param_name: GLenum, param_val: GLenum);
     fn is_enabled(&self, cap: GLenum) -> GLboolean;
+    fn is_query(&self, shader: GLuint) -> GLboolean;
     fn is_shader(&self, shader: GLuint) -> GLboolean;
     fn is_texture(&self, texture: GLenum) -> GLboolean;
     fn is_framebuffer(&self, framebuffer: GLenum) -> GLboolean;

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -1292,6 +1292,10 @@ impl Gl for GlFns {
         unsafe { self.ffi_gl_.IsEnabled(cap) }
     }
 
+    fn is_query(&self, query: GLuint) -> GLboolean {
+        unsafe { self.ffi_gl_.IsQuery(query) }
+    }
+
     fn is_shader(&self, shader: GLuint) -> GLboolean {
         unsafe { self.ffi_gl_.IsShader(shader) }
     }

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -1295,6 +1295,10 @@ impl Gl for GlesFns {
         unsafe { self.ffi_gl_.IsEnabled(cap) }
     }
 
+    fn is_query(&self, query: GLuint) -> GLboolean {
+        unsafe { self.ffi_gl_.IsQuery(query) }
+    }
+
     fn is_shader(&self, shader: GLuint) -> GLboolean {
         unsafe { self.ffi_gl_.IsShader(shader) }
     }


### PR DESCRIPTION
While most of the Query-related functions are there, `is_query` was missing.

References:
- https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsQuery.xhtml
- https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section-6.1.7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/202)
<!-- Reviewable:end -->
