### PR TITLE
Add missing sampler functions

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -171,6 +171,7 @@ declare_gl_apis! {
     fn gen_vertex_arrays(&self, n: GLsizei) -> Vec<GLuint>;
     fn gen_vertex_arrays_apple(&self, n: GLsizei) -> Vec<GLuint>;
     fn gen_queries(&self, n: GLsizei) -> Vec<GLuint>;
+    fn gen_samplers(&self, n: GLsizei) -> Vec<GLuint>;
     fn begin_query(&self, target: GLenum, id: GLuint);
     fn end_query(&self, target: GLenum);
     fn query_counter(&self, id: GLuint, target: GLenum);
@@ -179,6 +180,11 @@ declare_gl_apis! {
     fn get_query_object_i64v(&self, id: GLuint, pname: GLenum) -> i64;
     fn get_query_object_ui64v(&self, id: GLuint, pname: GLenum) -> u64;
     fn delete_queries(&self, queries: &[GLuint]);
+    fn delete_samplers(&self, samplers: &[GLuint]);
+    fn sampler_parameter_i(&self, sampler: GLenum, pname: GLenum, param: GLint);
+    fn sampler_parameter_f(&self, sampler: GLenum, pname: GLenum, param: GLfloat);
+    fn sampler_parameter_iv(&self, sampler: GLuint, pname: GLenum, params: &[GLint]);
+    fn sampler_parameter_fv(&self, sampler: GLuint, pname: GLenum, params: &[GLfloat]);
     fn delete_vertex_arrays(&self, vertex_arrays: &[GLuint]);
     fn delete_vertex_arrays_apple(&self, vertex_arrays: &[GLuint]);
     fn delete_buffers(&self, buffers: &[GLuint]);
@@ -215,6 +221,7 @@ declare_gl_apis! {
     fn bind_renderbuffer(&self, target: GLenum, renderbuffer: GLuint);
     fn bind_framebuffer(&self, target: GLenum, framebuffer: GLuint);
     fn bind_texture(&self, target: GLenum, texture: GLuint);
+    fn bind_sampler(&self, target: GLenum, sampler: GLuint);
     fn draw_buffers(&self, bufs: &[GLenum]);
     fn tex_image_2d(&self,
                     target: GLenum,
@@ -473,6 +480,7 @@ declare_gl_apis! {
     fn disable(&self, cap: GLenum);
     fn hint(&self, param_name: GLenum, param_val: GLenum);
     fn is_enabled(&self, cap: GLenum) -> GLboolean;
+    fn is_sampler(&self, shader: GLuint) -> GLboolean;
     fn is_shader(&self, shader: GLuint) -> GLboolean;
     fn is_texture(&self, texture: GLenum) -> GLboolean;
     fn is_framebuffer(&self, framebuffer: GLenum) -> GLboolean;

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -299,6 +299,49 @@ impl Gl for GlFns {
         }
     }
 
+    fn gen_samplers(&self, n: GLsizei) -> Vec<GLuint> {
+        let mut result = vec![0 as GLuint; n as usize];
+        unsafe {
+            self.ffi_gl_.GenSamplers(n, result.as_mut_ptr());
+        }
+        result
+    }
+
+    fn sampler_parameter_i(&self, sampler: GLuint, pname: GLenum, param: GLint) {
+        unsafe {
+            self.ffi_gl_.SamplerParameteri(sampler, pname, param);
+        }
+    }
+
+    fn sampler_parameter_f(&self, sampler: GLuint, pname: GLenum, param: GLfloat) {
+        unsafe {
+            self.ffi_gl_.SamplerParameterf(sampler, pname, param);
+        }
+    }
+
+    fn sampler_parameter_iv(&self, sampler: GLuint, pname: GLenum, params: &[GLint]) {
+        assert!(!params.is_empty());
+        unsafe {
+            self.ffi_gl_
+                .SamplerParameteriv(sampler, pname, params.as_ptr());
+        }
+    }
+
+    fn sampler_parameter_fv(&self, sampler: GLuint, pname: GLenum, params: &[GLfloat]) {
+        assert!(!params.is_empty());
+        unsafe {
+            self.ffi_gl_
+                .SamplerParameterfv(sampler, pname, params.as_ptr());
+        }
+    }
+
+    fn delete_samplers(&self, samplers: &[GLuint]) {
+        unsafe {
+            self.ffi_gl_
+                .DeleteSamplers(samplers.len() as GLsizei, samplers.as_ptr());
+        }
+    }
+
     fn delete_vertex_arrays(&self, vertex_arrays: &[GLuint]) {
         unsafe {
             self.ffi_gl_
@@ -500,6 +543,12 @@ impl Gl for GlFns {
     fn bind_texture(&self, target: GLenum, texture: GLuint) {
         unsafe {
             self.ffi_gl_.BindTexture(target, texture);
+        }
+    }
+
+    fn bind_sampler(&self, target: GLenum, sampler: GLuint) {
+        unsafe {
+            self.ffi_gl_.BindSampler(target, sampler);
         }
     }
 
@@ -1290,6 +1339,10 @@ impl Gl for GlFns {
 
     fn is_enabled(&self, cap: GLenum) -> GLboolean {
         unsafe { self.ffi_gl_.IsEnabled(cap) }
+    }
+
+    fn is_sampler(&self, sampler: GLuint) -> GLboolean {
+        unsafe { self.ffi_gl_.IsSampler(sampler) }
     }
 
     fn is_shader(&self, shader: GLuint) -> GLboolean {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -317,6 +317,49 @@ impl Gl for GlesFns {
         }
     }
 
+    fn gen_samplers(&self, n: GLsizei) -> Vec<GLuint> {
+        let mut result = vec![0 as GLuint; n as usize];
+        unsafe {
+            self.ffi_gl_.GenSamplers(n, result.as_mut_ptr());
+        }
+        result
+    }
+
+    fn sampler_parameter_i(&self, sampler: GLuint, pname: GLenum, param: GLint) {
+        unsafe {
+            self.ffi_gl_.SamplerParameteri(sampler, pname, param);
+        }
+    }
+
+    fn sampler_parameter_f(&self, sampler: GLuint, pname: GLenum, param: GLfloat) {
+        unsafe {
+            self.ffi_gl_.SamplerParameterf(sampler, pname, param);
+        }
+    }
+
+    fn sampler_parameter_iv(&self, sampler: GLuint, pname: GLenum, params: &[GLint]) {
+        assert!(!params.is_empty());
+        unsafe {
+            self.ffi_gl_
+                .SamplerParameteriv(sampler, pname, params.as_ptr());
+        }
+    }
+
+    fn sampler_parameter_fv(&self, sampler: GLuint, pname: GLenum, params: &[GLfloat]) {
+        assert!(!params.is_empty());
+        unsafe {
+            self.ffi_gl_
+                .SamplerParameterfv(sampler, pname, params.as_ptr());
+        }
+    }
+
+    fn delete_samplers(&self, samplers: &[GLuint]) {
+        unsafe {
+            self.ffi_gl_
+                .DeleteSamplers(samplers.len() as GLsizei, samplers.as_ptr());
+        }
+    }
+
     fn delete_vertex_arrays(&self, vertex_arrays: &[GLuint]) {
         unsafe {
             self.ffi_gl_
@@ -513,6 +556,12 @@ impl Gl for GlesFns {
     fn bind_texture(&self, target: GLenum, texture: GLuint) {
         unsafe {
             self.ffi_gl_.BindTexture(target, texture);
+        }
+    }
+
+    fn bind_sampler(&self, target: GLenum, sampler: GLuint) {
+        unsafe {
+            self.ffi_gl_.BindSampler(target, sampler);
         }
     }
 
@@ -1293,6 +1342,10 @@ impl Gl for GlesFns {
 
     fn is_enabled(&self, cap: GLenum) -> GLboolean {
         unsafe { self.ffi_gl_.IsEnabled(cap) }
+    }
+
+    fn is_sampler(&self, sampler: GLuint) -> GLboolean {
+        unsafe { self.ffi_gl_.IsSampler(sampler) }
     }
 
     fn is_shader(&self, shader: GLuint) -> GLboolean {


### PR DESCRIPTION
This patch adds the Sampler-related functions we're currently missing.

Reference: https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section-3.8.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/203)
<!-- Reviewable:end -->
