### PR TITLE
Add missing Sync-related functions

### DIFF
--- a/src/gl.rs
+++ b/src/gl.rs
@@ -474,6 +474,7 @@ declare_gl_apis! {
     fn hint(&self, param_name: GLenum, param_val: GLenum);
     fn is_enabled(&self, cap: GLenum) -> GLboolean;
     fn is_shader(&self, shader: GLuint) -> GLboolean;
+    fn is_sync(&self, sync: GLsync) -> GLboolean;
     fn is_texture(&self, texture: GLenum) -> GLboolean;
     fn is_framebuffer(&self, framebuffer: GLenum) -> GLboolean;
     fn is_renderbuffer(&self, renderbuffer: GLenum) -> GLboolean;
@@ -560,8 +561,9 @@ declare_gl_apis! {
     fn push_debug_group_khr(&self, source: GLenum, id: GLuint, message: &str);
     fn pop_debug_group_khr(&self);
     fn fence_sync(&self, condition: GLenum, flags: GLbitfield) -> GLsync;
-    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64);
+    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64) -> GLenum;
     fn wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64);
+    fn get_sync_iv(&self, sync: GLsync, pname: GLenum, buf_size: GLsizei, length: &mut GLsizei, values: &mut [GLint]);
     fn delete_sync(&self, sync: GLsync);
     fn texture_range_apple(&self, target: GLenum, data: &[u8]);
     fn gen_fences_apple(&self, n: GLsizei) -> Vec<GLuint>;

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -1296,6 +1296,10 @@ impl Gl for GlFns {
         unsafe { self.ffi_gl_.IsShader(shader) }
     }
 
+    fn is_sync(&self, sync: GLsync) -> GLboolean {
+        unsafe { self.ffi_gl_.IsSync(sync as *const _) }
+    }
+
     fn is_texture(&self, texture: GLenum) -> GLboolean {
         unsafe { self.ffi_gl_.IsTexture(texture) }
     }
@@ -1997,10 +2001,10 @@ impl Gl for GlFns {
         unsafe { self.ffi_gl_.FenceSync(condition, flags) as *const _ }
     }
 
-    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64) {
+    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64) -> GLenum {
         unsafe {
             self.ffi_gl_
-                .ClientWaitSync(sync as *const _, flags, timeout);
+                .ClientWaitSync(sync as *const _, flags, timeout)
         }
     }
 
@@ -2008,6 +2012,10 @@ impl Gl for GlFns {
         unsafe {
             self.ffi_gl_.WaitSync(sync as *const _, flags, timeout);
         }
+    }
+
+    fn get_sync_iv(&self, sync: GLsync, pname: GLenum, buf_size: GLsizei, length: &mut GLsizei, values: &mut [GLint]) {
+        unsafe { self.ffi_gl_.GetSynciv(sync as *const _, pname, buf_size, length, values.as_mut_ptr()) }
     }
 
     fn texture_range_apple(&self, target: GLenum, data: &[u8]) {

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -1299,6 +1299,10 @@ impl Gl for GlesFns {
         unsafe { self.ffi_gl_.IsShader(shader) }
     }
 
+    fn is_sync(&self, sync: GLsync) -> GLboolean {
+        unsafe { self.ffi_gl_.IsSync(sync as *const _) }
+    }
+
     fn is_texture(&self, texture: GLenum) -> GLboolean {
         unsafe { self.ffi_gl_.IsTexture(texture) }
     }
@@ -1994,10 +1998,10 @@ impl Gl for GlesFns {
         unsafe { self.ffi_gl_.FenceSync(condition, flags) as *const _ }
     }
 
-    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64) {
+    fn client_wait_sync(&self, sync: GLsync, flags: GLbitfield, timeout: GLuint64) -> GLenum {
         unsafe {
             self.ffi_gl_
-                .ClientWaitSync(sync as *const _, flags, timeout);
+                .ClientWaitSync(sync as *const _, flags, timeout)
         }
     }
 
@@ -2005,6 +2009,10 @@ impl Gl for GlesFns {
         unsafe {
             self.ffi_gl_.WaitSync(sync as *const _, flags, timeout);
         }
+    }
+
+    fn get_sync_iv(&self, sync: GLsync, pname: GLenum, buf_size: GLsizei, length: &mut GLsizei, values: &mut [GLint]) {
+        unsafe { self.ffi_gl_.GetSynciv(sync as *const _, pname, buf_size, length, values.as_mut_ptr()) }
     }
 
     fn delete_sync(&self, sync: GLsync) {


### PR DESCRIPTION
This patch adds missing functions for the GLsync.

Reference: https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#section.5.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/gleam/204)
<!-- Reviewable:end -->
