### PR TITLE
Use the Sealed marker trait trick on Gl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.8.0"
+version = "0.9.0"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"
@@ -9,4 +9,4 @@ repository = "https://github.com/servo/gleam"
 description = "Generated OpenGL bindings and wrapper for Servo."
 
 [build-dependencies]
-gl_generator = "0.13"
+gl_generator = "0.14"

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -21,6 +21,7 @@ impl GlFns {
     }
 }
 
+impl Sealed for GlFns {}
 impl Gl for GlFns {
     fn get_type(&self) -> GlType {
         GlType::Gl

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -21,6 +21,7 @@ impl GlesFns {
     }
 }
 
+impl Sealed for GlesFns {}
 impl Gl for GlesFns {
     fn get_type(&self) -> GlType {
         GlType::Gles


### PR DESCRIPTION
This makes adding methods to the Gl trait not a breaking change
anymore, given no one else outside the crate can implement
the trait in the first place anymore.