### PR TITLE
allow implementation of Gl trait outside of crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.9.2"
+version = "0.10.0"
 license = "Apache-2.0/MIT"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gl.rs
+++ b/src/gl.rs
@@ -74,22 +74,13 @@ pub struct DebugMessage {
     pub severity: GLenum,
 }
 
-mod private {
-    // Private marker trait extended by the Gl public trait so that no one
-    // else outside this crate can implement Gl. Why? So that adding new methods
-    // to it don't lead to a breaking change.
-    pub trait Sealed {}
-}
-use self::private::Sealed;
-
 macro_rules! declare_gl_apis {
     // garbo is a hack to handle unsafe methods.
     ($($(unsafe $([$garbo:expr])*)* fn $name:ident(&self $(, $arg:ident: $t:ty)* $(,)*) $(-> $retty:ty)* ;)+) => {
-        pub trait Gl: Sealed {
+        pub trait Gl {
             $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* ;)+
         }
 
-        impl Sealed for ErrorCheckingGl {}
         impl Gl for ErrorCheckingGl {
             $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* {
                 let rv = self.gl.$name($($arg,)*);
@@ -98,7 +89,6 @@ macro_rules! declare_gl_apis {
             })+
         }
 
-        impl<F> Sealed for ErrorReactingGl<F> {}
         impl<F: Fn(&dyn Gl, &str, GLenum)> Gl for ErrorReactingGl<F> {
             $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* {
                 let rv = self.gl.$name($($arg,)*);
@@ -110,7 +100,6 @@ macro_rules! declare_gl_apis {
             })+
         }
 
-        impl<F> Sealed for ProfilingGl<F> {}
         impl<F: Fn(&str, Duration)> Gl for ProfilingGl<F> {
             $($(unsafe $($garbo)*)* fn $name(&self $(, $arg:$t)*) $(-> $retty)* {
                 let start = Instant::now();

--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -21,7 +21,6 @@ impl GlFns {
     }
 }
 
-impl Sealed for GlFns {}
 impl Gl for GlFns {
     fn get_type(&self) -> GlType {
         GlType::Gl

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -21,7 +21,6 @@ impl GlesFns {
     }
 }
 
-impl Sealed for GlesFns {}
 impl Gl for GlesFns {
     fn get_type(&self) -> GlType {
         GlType::Gles


### PR DESCRIPTION
Firefox's software WebRender implementation requires the ability to implement the Gl trait from outside the crate so that we can pass it off to WebRender as an OpenGL implementation.

PR #207 broke this for us so we're currently blocked on this issue for integrating it into Firefox.