### PR TITLE
Flush explicitly before deleting textures on Mac

### DIFF
--- a/src/gl_fns.rs
+++ b/src/gl_fns.rs
@@ -345,6 +345,15 @@ impl Gl for GlFns {
 
     fn delete_textures(&self, textures: &[GLuint]) {
         unsafe {
+            #[cfg(target_os = "macos")]
+            {
+                // On the Mac the call to delete_textures() triggers a flush.
+                // But it happens at the wrong time, which can lead to crashes.
+                // To work around this we call flush() explicitly ourselves,
+                // before the call to delete_textures(). This helps fix
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1666293.
+                self.ffi_gl_.Flush();
+            }
             self.ffi_gl_
                 .DeleteTextures(textures.len() as GLsizei, textures.as_ptr());
         }


### PR DESCRIPTION
After landing my patch for https://bugzilla.mozilla.org/show_bug.cgi?id=1666293, I discovered that it would be bypassed by all calls to `gl.delete_textures` from Rust code in the Mozilla tree. So those calls are still effected by Apple's bug, for example [here](https://crash-stats.mozilla.org/report/index/4d936dd1-7c2e-4458-a887-2c71d0200923). As best I can tell, this patch will clear up the problem.

I'm submitting my patch here because the gleam crate, though included in the Mozilla code tree, is third party code.