### PR TITLE
Work around ANGLE bug in glGetDebugMessageLog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gleam"
-version = "0.15.0"
+version = "0.15.1"
 license = "MIT OR Apache-2.0"
 authors = ["The Servo Project Developers"]
 build = "build.rs"

--- a/src/gles_fns.rs
+++ b/src/gles_fns.rs
@@ -2110,7 +2110,7 @@ impl Gl for GlesFns {
         }
 
         let mut output = Vec::new();
-        const CAPACITY: usize = 4;
+        const CAPACITY: usize = 5;
 
         let mut msg_data = vec![0u8; CAPACITY * max_message_len as usize];
         let mut sources = [0 as GLenum; CAPACITY];
@@ -2121,8 +2121,11 @@ impl Gl for GlesFns {
 
         loop {
             let count = unsafe {
+                // ANGLE can return one more message than the count argument specifies,
+                // so we deliberately request one less than the capacity of our buffers.
+                // https://issues.angleproject.org/issues/425579207
                 self.ffi_gl_.GetDebugMessageLog(
-                    CAPACITY as _,
+                    (CAPACITY - 1) as _,
                     msg_data.len() as _,
                     sources.as_mut_ptr(),
                     types.as_mut_ptr(),
@@ -2132,9 +2135,10 @@ impl Gl for GlesFns {
                     msg_data.as_mut_ptr() as *mut _,
                 )
             };
+            let count = CAPACITY.min(count as usize);
 
             let mut offset = 0;
-            output.extend((0..count as usize).map(|i| {
+            output.extend((0..count).map(|i| {
                 let len = lengths[i] as usize;
                 let slice = &msg_data[offset..offset + len];
                 offset += len;


### PR DESCRIPTION
ANGLE has a bug where it may return one too many messages from glGetDebugMessageLog.

Reported upstream here: https://issues.angleproject.org/issues/425579207

To avoid this, ensure the buffers we provide to the function have a capacity one greater than the count we provide. This shouldn't have any negative effect on other drivers, so I think it's okay to apply this workaround universally.